### PR TITLE
fix: feed cleanup before creating

### DIFF
--- a/src/triggers.js
+++ b/src/triggers.js
@@ -25,6 +25,13 @@ class Triggers {
     const ret = await this.owclient.triggers.create(options)
     if (options && options.trigger && options.trigger.feed) {
       try {
+        // Feed update does not work if the feed is not already present and create fails if it's already there.
+        // So we are deleting it and ignoring the error if any.
+        try {
+          await this.owclient.feeds.delete({ name: options.trigger.feed, trigger: options.name })
+        } catch (err) {
+          // Ignore
+        }
         await this.owclient.feeds.create({ name: options.trigger.feed, trigger: options.name, params: createKeyValueObjectFromArray(options.trigger.parameters) })
       } catch (err) {
         await this.owclient.triggers.delete(options)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Feed update does not work if the feed is not already present and create fails if it's already there.
So we are deleting it and ignoring the error if any.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
