### PR TITLE
Support for multiple packages in app manifest

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -18,13 +18,16 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-runtime
 
 // need config.root
 // config.actions.dist
-const buildAction = async (name, action, root, dist) => {
+const buildAction = async (packageName, actionName, action, root, dist) => {
   // const actionPath = path.isAbsolute(action.function) ? action.function : path.join(root, action.function)
   // note: it does not seem to be possible to get here with an absolute path ...
+/*   console.log(name)
+  console.log(action) */
   const actionPath = path.join(root, action.function)
 
-  const outPath = path.join(dist, `${name}.zip`)
-  const tempBuildDir = path.join(path.dirname(outPath), `${name}-temp`) // build all to tempDir first
+  const outPath = path.join(dist, `${packageName}-${actionName}.zip`)
+  // console.log(outPath)
+  const tempBuildDir = path.join(path.dirname(outPath), `${packageName}-${actionName}-temp`) // build all to tempDir first
   const actionFileStats = fs.lstatSync(actionPath)
 
   // make sure temp/ exists
@@ -121,26 +124,28 @@ const buildActions = async (config, filterActions) => {
   }
   // clear out dist dir
   fs.emptyDirSync(config.actions.dist)
-
-  let packageToBuild = config.manifest.package
+  // console.log(config)
+  /* let packageToBuild = config.manifest.package
   // which actions to build, check filter
   if (!packageToBuild) {
     const firstPkgName = Object.keys(config.manifest.full.packages)[0]
     packageToBuild = config.manifest.full.packages[firstPkgName]
-  }
+  } */
   // todo: build ALL actions of ALL packages
-  let actionsToBuild = Object.entries(packageToBuild.actions)
-  if (Array.isArray(filterActions)) {
-    actionsToBuild = actionsToBuild.filter(([name, value]) => filterActions.includes(name))
-  }
-
   const builtList = []
-  // build all sequentially (todo make bundler execution parallel)
-  for (const [name, action] of actionsToBuild) {
-    // const out =  // todo: log output of each action as it is built
-    // need config.root
-    // config.actions.dist
-    builtList.push(await buildAction(name, action, config.root, config.actions.dist))
+  for (const [pkgName, pkg] of Object.entries(config.manifest.full.packages)) {
+    let actionsToBuild = Object.entries(pkg.actions)
+
+    // build all sequentially (todo make bundler execution parallel)
+    for (const [actionName, action] of actionsToBuild) {
+      if (Array.isArray(filterActions) && !filterActions.includes(actionName)) {
+        continue
+      }
+      // const out =  // todo: log output of each action as it is built
+      // need config.root
+      // config.actions.dist
+      builtList.push(await buildAction(pkgName, actionName, action, config.root, config.actions.dist))
+    }
   }
   return builtList
 }

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -119,6 +119,7 @@ const buildAction = async (packageName, actionName, action, root, dist) => {
 }
 
 const buildActions = async (config, filterActions) => {
+  // console.log(config)
   if (!config.app.hasBackend) {
     throw new Error('cannot build actions, app has no backend')
   }
@@ -131,9 +132,9 @@ const buildActions = async (config, filterActions) => {
     const firstPkgName = Object.keys(config.manifest.full.packages)[0]
     packageToBuild = config.manifest.full.packages[firstPkgName]
   } */
-  // todo: build ALL actions of ALL packages
+  const modifiedConfig = utils.replacePackagePlaceHolder(config)
   const builtList = []
-  for (const [pkgName, pkg] of Object.entries(config.manifest.full.packages)) {
+  for (const [pkgName, pkg] of Object.entries(modifiedConfig.manifest.full.packages)) {
     let actionsToBuild = Object.entries(pkg.actions)
 
     // build all sequentially (todo make bundler execution parallel)

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -139,7 +139,7 @@ const buildActions = async (config, filterActions) => {
   const modifiedConfig = utils.replacePackagePlaceHolder(config)
   const builtList = []
   for (const [pkgName, pkg] of Object.entries(modifiedConfig.manifest.full.packages)) {
-    let actionsToBuild = Object.entries(pkg.actions)
+    const actionsToBuild = Object.entries(pkg.actions)
 
     // build all sequentially (todo make bundler execution parallel)
     for (const [actionName, action] of actionsToBuild) {

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -66,9 +66,9 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   } */
 
   const relDist = utils._relApp(config.root, config.actions.dist)
-  for ( const [pkgName, pkg] of Object.entries(manifest.packages)) {
+  for (const [pkgName, pkg] of Object.entries(manifest.packages)) {
     pkg.version = config.app.version
-    for ( const [name, action] of Object.entries(pkg.actions)) {
+    for (const [name, action] of Object.entries(pkg.actions)) {
       // change path to built action
       action.function = path.join(relDist, pkgName + '-' + name + '.zip')
     }

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -34,6 +34,7 @@ const IOruntime = require('./RuntimeAPI')
  * @returns {Promise<object>} deployedEntities
  */
 async function deployActions (config, deployConfig = {}, logFunc) {
+  // console.log(config)
   if (!config.app.hasBackend) throw new Error('cannot deploy actions, app has no backend')
   // TODO: Should we still support emitting events (start, progress, end ... )
 
@@ -52,26 +53,26 @@ async function deployActions (config, deployConfig = {}, logFunc) {
     throw new Error(`missing files in ${utils._relApp(config.root, dist)}, maybe you forgot to build your actions ?`)
   }
 
+  const modifiedConfig = utils.replacePackagePlaceHolder(config)
+
   // 1. rewrite wskManifest config
-  const manifest = deepCopy(config.manifest.full)
-  let manifestPackage = manifest.packages[config.manifest.packagePlaceholder]
+  const manifest = modifiedConfig.manifest.full
+  /* let manifestPackage = manifest.packages[config.manifest.packagePlaceholder]
   const usingCustomPackageName = !manifestPackage
   if (usingCustomPackageName) {
     const packageNames = Object.keys(manifest.packages)
-    manifestPackage = manifest.packages[packageNames[0]]
+    // manifestPackage = manifest.packages[packageNames[0]]
     config.ow.package = packageNames[0]
-    // this is needed for getActionUrls not to fail
-    config.manifest.package = config.manifest.full.packages[packageNames[0]]
-  }
+  } */
 
   const relDist = utils._relApp(config.root, config.actions.dist)
-  await Promise.all(Object.entries(manifest.packages).map(async ([pkgName, pkg]) => {
+  for ( const [pkgName, pkg] of Object.entries(manifest.packages)) {
     pkg.version = config.app.version
-    await Promise.all(Object.entries(pkg.actions).map(async ([name, action]) => {
+    for ( const [name, action] of Object.entries(pkg.actions)) {
       // change path to built action
       action.function = path.join(relDist, pkgName + '-' + name + '.zip')
-    }))
-  }))
+    }
+  }
   /* manifestPackage.version = config.app.version
   const relDist = utils._relApp(config.root, config.actions.dist)
   await Promise.all(Object.entries(manifestPackage.actions).map(async ([name, action]) => {
@@ -79,11 +80,6 @@ async function deployActions (config, deployConfig = {}, logFunc) {
     action.function = path.join(relDist, config.ow.package + '-' + name + '.zip')
   })) */
   // console.log(manifest)
-  if (!usingCustomPackageName) {
-    // replace package name
-    manifest.packages[config.ow.package] = manifest.packages[config.manifest.packagePlaceholder]
-    delete manifest.packages[config.manifest.packagePlaceholder]
-  }
   // console.log(config)
   // console.log(manifest)
   // return

--- a/src/undeploy-actions.js
+++ b/src/undeploy-actions.js
@@ -38,7 +38,6 @@ async function undeployActions (config, logFunc) {
   const modifiedConfig = utils.replacePackagePlaceHolder(config)
   const manifest = modifiedConfig.manifest.full
   for (const [packageName, pkg] of Object.entries(manifest.packages)) {
-    // TODO: Do we still need this?
     pkg.version = config.app.version
     await undeployWsk(packageName, manifest, owOptions, log)
   }
@@ -81,7 +80,6 @@ async function undeployWsk (packageName, manifestContent, owOptions, logger) {
 
   // 4. add apis and rules to undeployment, apis and rules are not part of the managed whisk project as they don't support annotations and
   //    hence can't be retrieved with getProjectEntities + api delete is idempotent so no risk of 404s
-  // TODO: Get manifest entities from a single package. This is fine for now since undeploy does not have filter feature
   const manifestEntities = utils.processPackage(manifestContent.packages, {}, {}, {}, true)
   entities.apis = manifestEntities.apis
   entities.rules = manifestEntities.rules

--- a/src/undeploy-actions.js
+++ b/src/undeploy-actions.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 const utils = require('./utils')
-const cloneDeep = require('lodash.clonedeep')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-runtime:undeploy', { provider: 'debug' })
 const IORuntime = require('./RuntimeAPI')
 
@@ -38,13 +37,11 @@ async function undeployActions (config, logFunc) {
   // replace package name
   const modifiedConfig = utils.replacePackagePlaceHolder(config)
   const manifest = modifiedConfig.manifest.full
-  for ( const [packageName, pkg] of Object.entries(manifest.packages) ) {
+  for (const [packageName, pkg] of Object.entries(manifest.packages)) {
     // TODO: Do we still need this?
     pkg.version = config.app.version
-
     await undeployWsk(packageName, manifest, owOptions, log)
   }
-
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1734,13 +1734,13 @@ function checkOpenWhiskCredentials (config) {
 function getActionUrls (appConfig, /* istanbul ignore next */ isRemoteDev = false, /* istanbul ignore next */ isLocalDev = false) {
   // set action urls
   // action urls {name: url}, if !LocalDev subdomain uses namespace
-  let actionsAndSequences = {}
+  const actionsAndSequences = {}
   // console.log(appConfig)
-  let config = replacePackagePlaceHolder(appConfig)
+  const config = replacePackagePlaceHolder(appConfig)
   // console.log(config)
   Object.entries(config.manifest.full.packages).forEach(([pkgName, pkg]) => {
     // const actualPkgName = pkgName.replace(config.manifest.packagePlaceholder, config.ow.package)
-    Object.entries(pkg.actions || {}).forEach(([actionName, action]) => {
+    Object.entries(pkg.actions).forEach(([actionName, action]) => {
       actionsAndSequences[pkgName + '/' + actionName] = action
     })
     Object.entries(pkg.sequences || {}).forEach(([actionName, action]) => {
@@ -1792,17 +1792,17 @@ function removeProtocolFromURL (url) {
 }
 
 function replacePackagePlaceHolder (config) {
-  // TODO: Should we read the first package and put it in config.ow.package ?
-  if (!config.ow.package) { // Either the placeHolder does not exist or it has already been modified
-    console.log('No config.ow.package. Returning same config')
-    return config
-  }
   const modifiedConfig = cloneDeep(config)
-  const modifiedPackages = modifiedConfig.manifest.full.packages
+  const packages = modifiedConfig.manifest.full.packages
   const packagePlaceholder = modifiedConfig.manifest.packagePlaceholder
-  if(modifiedPackages[packagePlaceholder]) {
-    modifiedPackages[config.ow.package] = modifiedPackages[packagePlaceholder]
-    delete modifiedPackages[packagePlaceholder]
+  if (packages[packagePlaceholder]) {
+    packages[config.ow.package] = packages[packagePlaceholder]
+    delete packages[packagePlaceholder]
+  } else {
+    // Using custom package name.
+    // Set config.ow.package so that syncProject can use it as project name for annotations.
+    const packageNames = Object.keys(packages)
+    config.ow.package = packageNames[0]
   }
   return modifiedConfig
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1735,11 +1735,8 @@ function getActionUrls (appConfig, /* istanbul ignore next */ isRemoteDev = fals
   // set action urls
   // action urls {name: url}, if !LocalDev subdomain uses namespace
   const actionsAndSequences = {}
-  // console.log(appConfig)
   const config = replacePackagePlaceHolder(appConfig)
-  // console.log(config)
   Object.entries(config.manifest.full.packages).forEach(([pkgName, pkg]) => {
-    // const actualPkgName = pkgName.replace(config.manifest.packagePlaceholder, config.ow.package)
     Object.entries(pkg.actions).forEach(([actionName, action]) => {
       actionsAndSequences[pkgName + '/' + actionName] = action
     })
@@ -1747,8 +1744,6 @@ function getActionUrls (appConfig, /* istanbul ignore next */ isRemoteDev = fals
       actionsAndSequences[pkgName + '/' + actionName] = action
     })
   })
-  // console.log(actionsAndSequences)
-  // return
   return Object.entries(actionsAndSequences).reduce((obj, [name, action]) => {
     const webArg = action['web-export'] || action.web
     const webUri = (webArg && webArg !== 'no' && webArg !== 'false') ? 'web' : ''

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -438,6 +438,14 @@ test('use buildConfig.filterActions to build only action called `action-zip`', a
     n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
 })
 
+test('use buildConfig.filterActions to build only action called `sample-app-1.0.0/action-zip`', async () => {
+  addSampleAppFiles()
+  await buildActions(global.sampleAppConfig, ['sample-app-1.0.0/action-zip'])
+  expect(utils.zip).toHaveBeenCalledTimes(1)
+  expect(utils.zip).toHaveBeenCalledWith(expect.stringContaining(n('/dist/actions/sample-app-1.0.0-action-zip-temp')),
+    n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
+})
+
 test('No backend is present', async () => {
   addSampleAppFiles()
   // global.fakeFileSystem.removeKeys(['./manifest.yml'])

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -76,7 +76,8 @@ describe('build by zipping js action folder', () => {
     // delete non zip action (focus only on zip case)
     // vol.unlinkSync('/actions/action.js')
     config = deepClone(global.sampleAppConfig)
-    delete config.manifest.package.actions.action
+    // delete config.manifest.package.actions.action
+    delete config.manifest.full.packages.__APP_PACKAGE__.actions.action
   })
 
   afterEach(() => {
@@ -100,7 +101,7 @@ describe('build by zipping js action folder', () => {
   test('should build a zip action folder with a package.json and action named index.js', async () => {
     // console.log(config)
     await buildActions(config)
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-zip-temp'), n('/dist/actions/action-zip.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-zip-temp'), n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
   })
 
   /*
@@ -139,7 +140,7 @@ describe('build by zipping js action folder', () => {
       'actions/action-zip/sample.js': global.fixtureFile('/sample-app/actions/action-zip/index.js')
     })
     const res = await buildActions(config)
-    expect(res).toEqual(expect.arrayContaining([n('/dist/actions/action-zip.zip')]))
+    expect(res).toEqual(expect.arrayContaining([n('/dist/actions/sample-app-1.0.0-action-zip.zip')]))
   })
 
   test('should fail if package.json main field is not defined and there is no index.js file', async () => {
@@ -179,7 +180,7 @@ describe('build by zipping js action folder', () => {
     })
     await buildActions(config)
     expect(webpackMock.run).toHaveBeenCalledTimes(0) // no webpack bundling
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-zip-temp'), n('/dist/actions/action-zip.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-zip-temp'), n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
   })
 
   test('should build a zip action package.json main field points to file not called index.js', async () => {
@@ -197,7 +198,7 @@ describe('build by zipping js action folder', () => {
 
     await buildActions(config)
     expect(webpackMock.run).toHaveBeenCalledTimes(0) // no webpack bundling
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-zip-temp'), n('/dist/actions/action-zip.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-zip-temp'), n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
   })
 })
 
@@ -230,7 +231,8 @@ describe('build by bundling js action file with webpack', () => {
     vol.unlinkSync('/actions/action-zip/package.json')
     vol.rmdirSync('/actions/action-zip') */
     config = deepClone(global.sampleAppConfig)
-    delete config.manifest.package.actions['action-zip']
+    // delete config.manifest.package.actions['action-zip']
+    delete config.manifest.full.packages.__APP_PACKAGE__.actions['action-zip']
   })
 
   afterEach(() => {
@@ -255,11 +257,11 @@ describe('build by bundling js action file with webpack', () => {
     expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
       entry: [n('/actions/action.js')],
       output: expect.objectContaining({
-        path: n('/dist/actions/action-temp'),
+        path: n('/dist/actions/sample-app-1.0.0-action-temp'),
         filename: 'index.js'
       })
     }))
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'), n('/dist/actions/action.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-temp'), n('/dist/actions/sample-app-1.0.0-action.zip'))
   })
 
   test('should bundle a single action file using webpack and zip it', async () => {
@@ -268,11 +270,11 @@ describe('build by bundling js action file with webpack', () => {
     expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
       entry: [n('/actions/action.js')],
       output: expect.objectContaining({
-        path: n('/dist/actions/action-temp'),
+        path: n('/dist/actions/sample-app-1.0.0-action-temp'),
         filename: 'index.js'
       })
     }))
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'), n('/dist/actions/action.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-temp'), n('/dist/actions/sample-app-1.0.0-action.zip'))
   })
 
   test('should bundle a single action file using webpack and zip it with includes', async () => {
@@ -290,11 +292,11 @@ describe('build by bundling js action file with webpack', () => {
     expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
       entry: [n('/actions/action.js')],
       output: expect.objectContaining({
-        path: n('/dist/actions/action-temp'),
+        path: n('/dist/actions/sample-app-include-1.0.0-action-temp'),
         filename: 'index.js'
       })
     }))
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'), n('/dist/actions/action.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-include-1.0.0-action-temp'), n('/dist/actions/sample-app-include-1.0.0-action.zip'))
     expect(Object.keys(global.fakeFileSystem.files())).toEqual(expect.arrayContaining(['/includeme.txt']))
   })
 
@@ -317,11 +319,11 @@ describe('build by bundling js action file with webpack', () => {
     expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
       entry: [n('/actions/action.js')],
       output: expect.objectContaining({
-        path: n('/dist/actions/action-temp'),
+        path: n('/dist/actions/bobby-mcgee-action-temp'),
         filename: 'index.js'
       })
     }))
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'), n('/dist/actions/action.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/bobby-mcgee-action-temp'), n('/dist/actions/bobby-mcgee-action.zip'))
   })
 
   test('should still bundle a single action file when there is no ui', async () => {
@@ -331,11 +333,11 @@ describe('build by bundling js action file with webpack', () => {
     expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
       entry: [n('/actions/action.js')],
       output: expect.objectContaining({
-        path: n('/dist/actions/action-temp'),
+        path: n('/dist/actions/sample-app-1.0.0-action-temp'),
         filename: 'index.js'
       })
     }))
-    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'), n('/dist/actions/action.zip'))
+    expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-temp'), n('/dist/actions/sample-app-1.0.0-action.zip'))
   })
 
   test('should fail if webpack throws an error', async () => {
@@ -392,15 +394,15 @@ test('should build 1 zip action and 1 bundled action in one go', async () => {
   expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
     entry: [n('/actions/action.js')],
     output: expect.objectContaining({
-      path: expect.stringContaining(n('/dist/actions/action-temp')),
+      path: expect.stringContaining(n('/dist/actions/sample-app-1.0.0-action-temp')),
       filename: 'index.js'
     })
   }))
   expect(utils.zip).toHaveBeenCalledTimes(2)
-  expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-temp'),
-    n('/dist/actions/action.zip'))
-  expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/action-zip-temp'),
-    n('/dist/actions/action-zip.zip'))
+  expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-temp'),
+    n('/dist/actions/sample-app-1.0.0-action.zip'))
+  expect(utils.zip).toHaveBeenCalledWith(n('/dist/actions/sample-app-1.0.0-action-zip-temp'),
+    n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
 })
 
 test('use buildConfig.filterActions to build only action called `action`', async () => {
@@ -419,21 +421,21 @@ test('use buildConfig.filterActions to build only action called `action`', async
   expect(webpack).toHaveBeenCalledWith(expect.objectContaining({
     entry: [n('/actions/action.js')],
     output: expect.objectContaining({
-      path: n('/dist/actions/action-temp'),
+      path: n('/dist/actions/sample-app-1.0.0-action-temp'),
       filename: 'index.js'
     })
   }))
   expect(utils.zip).toHaveBeenCalledTimes(1)
-  expect(utils.zip).toHaveBeenCalledWith(expect.stringContaining(n('/dist/actions/action-temp')),
-    n('/dist/actions/action.zip'))
+  expect(utils.zip).toHaveBeenCalledWith(expect.stringContaining(n('/dist/actions/sample-app-1.0.0-action-temp')),
+    n('/dist/actions/sample-app-1.0.0-action.zip'))
 })
 
 test('use buildConfig.filterActions to build only action called `action-zip`', async () => {
   addSampleAppFiles()
   await buildActions(global.sampleAppConfig, ['action-zip'])
   expect(utils.zip).toHaveBeenCalledTimes(1)
-  expect(utils.zip).toHaveBeenCalledWith(expect.stringContaining(n('/dist/actions/action-zip-temp')),
-    n('/dist/actions/action-zip.zip'))
+  expect(utils.zip).toHaveBeenCalledWith(expect.stringContaining(n('/dist/actions/sample-app-1.0.0-action-zip-temp')),
+    n('/dist/actions/sample-app-1.0.0-action-zip.zip'))
 })
 
 test('No backend is present', async () => {

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -43,12 +43,12 @@ const expectedDistManifest = {
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         },
         'action-zip': {
-          function: path.normalize('dist/actions/action-zip.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action-zip.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -124,7 +124,10 @@ test('deploy full manifest with package name specified', async () => {
   runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
 
   const expectedNamedPackage = {
-    'bobby-mcgee': expectedDistManifest.packages['sample-app-1.0.0']
+    'bobby-mcgee': deepCopy(expectedDistManifest.packages['sample-app-1.0.0'])
+  }
+  for (const actionTuple of Object.entries(expectedNamedPackage['bobby-mcgee'].actions)) {
+    actionTuple[1].function = actionTuple[1].function.replace(/sample-app-1.0.0/g, 'bobby-mcgee')
   }
 
   const buildDir = global.namedPackageConfig.actions.dist
@@ -166,7 +169,7 @@ test('use deployConfig.filterEntities to deploy only one action', async () => {
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -205,7 +208,7 @@ test('use deployConfig.filterEntities to deploy only one trigger and one action'
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -247,7 +250,7 @@ test('use deployConfig.filterEntities to deploy only one trigger and one action 
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -295,7 +298,7 @@ test('use deployConfig.filterEntities to deploy only one action and one api', as
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -345,12 +348,12 @@ test('use deployConfig.filterEntities to deploy only two actions and one sequenc
       version: '1.0.0',
       actions: {
         action: {
-          function: path.normalize('dist/actions/action.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         },
         'action-zip': {
-          function: path.normalize('dist/actions/action-zip.zip'),
+          function: path.normalize('dist/actions/sample-app-1.0.0-action-zip.zip'),
           runtime: 'nodejs:12',
           web: 'yes'
         }
@@ -429,7 +432,7 @@ test('use deployConfig.filterEntities on non existing pkgEntity should work', as
         version: '1.0.0',
         actions: {
           action: {
-            function: path.normalize('dist/actions/action.zip'),
+            function: path.normalize('dist/actions/sample-app-reduced-1.0.0-action.zip'),
             runtime: 'nodejs:12',
             web: 'yes'
           }
@@ -481,8 +484,8 @@ test('if actions are deployed and part of the manifest it should return their ur
   // mock deployed entities
   runtimeLibUtils.processPackage.mockReturnValue({
     actions: [
-      { name: 'pkg/action' }, // must be referenced in fixture manifest file
-      { name: 'pkg/actionNotInManifest' }
+      { name: 'sample-app-reduced-1.0.0/action' }, // must be referenced in fixture manifest file
+      { name: 'sample-app-reduced-1.0.0/actionNotInManifest' }
     ]
   })
 
@@ -495,11 +498,11 @@ test('if actions are deployed and part of the manifest it should return their ur
   expect(returnedEntities).toEqual({
     actions: [
       {
-        name: 'pkg/action',
+        name: 'sample-app-reduced-1.0.0/action',
         // no UI in sample-app reduced so url is pointing to adobeioruntime instead of cdn
         url: 'https://fake_ns.adobeioruntime.net/api/v1/web/sample-app-reduced-1.0.0/action'
       },
-      { name: 'pkg/actionNotInManifest' }
+      { name: 'sample-app-reduced-1.0.0/actionNotInManifest' }
     ]
   })
 })
@@ -510,8 +513,8 @@ test('if actions are deployed with custom package and part of the manifest it sh
   // mock deployed entities
   runtimeLibUtils.processPackage.mockReturnValue({
     actions: [
-      { name: 'pkg/action' }, // must be referenced in fixture manifest file
-      { name: 'pkg/actionNotInManifest' }
+      { name: 'bobby-mcgee/action' }, // must be referenced in fixture manifest file
+      { name: 'bobby-mcgee/actionNotInManifest' }
     ]
   })
 
@@ -524,10 +527,10 @@ test('if actions are deployed with custom package and part of the manifest it sh
   expect(returnedEntities).toEqual({
     actions: [
       {
-        name: 'pkg/action',
+        name: 'bobby-mcgee/action',
         url: 'https://fake_ns.adobeio-static.net/api/v1/web/bobby-mcgee/action'
       },
-      { name: 'pkg/actionNotInManifest' }
+      { name: 'bobby-mcgee/actionNotInManifest' }
     ]
   })
 })

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -238,7 +238,7 @@ test('use deployConfig.filterEntities to deploy only one trigger and one action 
 
   await deployActions(global.sampleAppConfig, {
     filterEntities: {
-      actions: ['action'],
+      actions: ['sample-app-1.0.0/action'],
       triggers: ['trigger1'],
       rules: ['rule1']
     }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1536,9 +1536,9 @@ describe('getActionUrls', () => {
 
   test('local dev false', () => {
     const expected = {
-      action: 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
-      'action-sequence': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-sequence',
-      'action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip'
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip'
     }
 
     const result = utils.getActionUrls(config, config.actions.devRemote, false)
@@ -1547,9 +1547,9 @@ describe('getActionUrls', () => {
 
   test('local dev true', () => {
     const expected = {
-      action: 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action',
-      'action-sequence': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-sequence',
-      'action-zip': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-zip'
+      'sample-app-1.0.0/action': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-zip'
     }
     const result = utils.getActionUrls(config, config.actions.devRemote, true)
     expect(result).toEqual(expect.objectContaining(expected))
@@ -1557,12 +1557,12 @@ describe('getActionUrls', () => {
 
   test('web false', () => {
     const expected = {
-      action: 'https://adobeioruntime.net/api/v1/fake_ns/sample-app-1.0.0/action',
-      'action-sequence': 'https://adobeioruntime.net/api/v1/fake_ns/sample-app-1.0.0/action-sequence',
-      'action-zip': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-zip'
+      'sample-app-1.0.0/action': 'https://adobeioruntime.net/api/v1/fake_ns/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://adobeioruntime.net/api/v1/fake_ns/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://adobeioruntime.net/api/v1/web/fake_ns/sample-app-1.0.0/action-zip'
     }
-    config.manifest.package.actions.action.web = 'no'
-    config.manifest.package.sequences['action-sequence'].web = false
+    config.manifest.full.packages.__APP_PACKAGE__.actions.action.web = 'no'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = false
     const result = utils.getActionUrls(config, config.actions.devRemote, true)
     expect(result).toEqual(expect.objectContaining(expected))
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/adobe/aio-cli-plugin-app/issues/276
- Adding support for multiple packages in app manifest.
- Backward compatibility is maintained for deploying specific actions instead of the whole manifest.
- `aio app deploy --action hello` will still deploy just the `hello` action in the default/first package.
- To deploy actions from custom user defined packages, use `aio app deploy --action <packageName>/hello`

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
