### PR TITLE
Allow for external log banners.

### DIFF
--- a/test/print.action.logs.test.js
+++ b/test/print.action.logs.test.js
@@ -67,6 +67,38 @@ describe('printActionLogs', () => {
     expect(logger).not.toHaveBeenCalled()
   })
 
+  test('(config, limit=3, custom banner) and 3 activations and no logs', async () => {
+    const activations = [
+      { activationId: 123, start: 555555, name: 'one' },
+      { activationId: 456, start: 555666, name: 'two' },
+      { activationId: 100, start: 666666, name: 'three' }
+    ]
+    owListActivationMock.mockResolvedValue(activations)
+    owLogsActivationMock.mockResolvedValue({ logs: [] })
+
+    const mockBannerLogger = jest.fn()
+    await printActionLogs(fakeConfig, { bannerFunc: mockBannerLogger }, 3)
+
+    expect(mockBannerLogger).toHaveBeenCalledTimes(3)
+    expect(mockBannerLogger).toHaveBeenNthCalledWith(1, activations[2], [])
+    expect(mockBannerLogger).toHaveBeenNthCalledWith(2, activations[1], [])
+    expect(mockBannerLogger).toHaveBeenNthCalledWith(3, activations[0], [])
+  })
+
+  test('(config, limit=3, custom logger) and 3 activations with logs', async () => {
+    const activations = [
+      { activationId: 123, start: 555555, name: 'one', annotations: [] },
+      { activationId: 456, start: 555666, name: 'two', annotations: [] },
+      { activationId: 100, start: 666666, name: 'three', annotations: [{ key: 'path', value: 'three' }] }
+    ]
+    owListActivationMock.mockResolvedValue(activations)
+    owLogsActivationMock.mockResolvedValue({ logs: ['ABC'] })
+
+    const mockCustomLogger = jest.fn()
+    await printActionLogs(fakeConfig, { logFunc: mockCustomLogger }, 3)
+    expect(mockCustomLogger).toHaveBeenCalledTimes(3 + 1) // only one activation has annotations for a banner
+  })
+
   test('(config, limit=3, logger) and 3 activations and no logs', async () => {
     owListActivationMock.mockResolvedValue([
       { activationId: 123, start: 555555, name: 'one' },

--- a/types.d.ts
+++ b/types.d.ts
@@ -368,6 +368,9 @@ declare function printLogs(activation: any, strip: boolean, logger: any): void;
  * Filters and prints action logs.
  * @param runtime - runtime (openwhisk) object
  * @param logger - an instance of a logger to emit messages to
+ *    undefined = console.log
+ *    logger = use this logger
+ *    { logFunc?, bannerFunc? } = use given logFunc for logs and bannerFunc for activation banner
  * @param limit - maximum number of activations to fetch logs from
  * @param filterActions - array of actions to fetch logs from
  *    ['pkg1/'] = logs of all deployed actions under package pkg1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Factors the activation banner printing into a function that can be overriden.

## Related Issue

See https://github.com/adobe/aio-lib-runtime/issues/27.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This refactoring is semantic preserving but provides flexibility for downstream plugins to provide their own banner implementation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
