### PR TITLE
feat: Support for package params in manifest

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1183,6 +1183,18 @@ function processPackage (packages,
     if (pkgs[key].public) {
       objPackage.package = { publish: pkgs[key].public }
     }
+    let pkgDeploymentInputs = {}
+    const packageInputs = pkgs[key].inputs || {}
+    if (deploymentPkgs[key]) {
+      pkgDeploymentInputs = deploymentPkgs[key].inputs || {}
+    }
+    const allPkgInputs = returnUnion(packageInputs, pkgDeploymentInputs)
+    // if parameter is provided as key : 'data type' , process it to set default values before deployment
+    if (Object.entries(allPkgInputs).length !== 0) {
+      const processedInput = createKeyValueInput(processInputs(allPkgInputs, params))
+      objPackage.package = objPackage.package || {}
+      objPackage.package.parameters = processedInput
+    }
     pkgAndDeps.push(objPackage)
     // From wskdeploy repo : currently, the 'version' and 'license' values are not stored in Apache OpenWhisk, but there are plans to support it in the future
     // pkg.version = packages[key]['version']

--- a/test/__fixtures__/deploy/pkgparam_manifest_res.json
+++ b/test/__fixtures__/deploy/pkgparam_manifest_res.json
@@ -1,0 +1,113 @@
+{
+    "pkgAndDeps": [
+        {
+            "name": "hello",
+            "package": {
+                "parameters": [{
+                  "key": "my-pkg-param",
+                  "value": "pkg-param-value"
+                }]
+              }
+        },
+        {
+            "name": "mypackage",
+            "package": {
+                "binding": {
+                    "namespace": "adobeio",
+                    "name": "oauth"
+                }
+            }
+        }
+    ],
+    "apis": [
+        {
+            "action": "hello/helloAction",
+            "basepath": "/hello",
+            "name": "hello-world",
+            "operation": "GET",
+            "relpath": "/world",
+            "responsetype": "json"
+        }
+    ],
+    "triggers": [
+        {
+            "name": "hellotrigger",
+            "trigger": {
+                "parameters": [
+                    {
+                        "key": "cron",
+                        "value": "* * * * *"
+                    },
+                    {
+                        "key": "trigger_payload",
+                        "value": "{\"message\": \"hello world!\"}"
+                    }
+                ],
+                "feed": "/whisk.system/alarms/alarm",
+                "annotations":[{
+                    "key": "ann1",
+                    "value": "annvalue"
+                }]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "name": "reportEveryMinute",
+            "trigger": "hellotrigger",
+            "action": "hello/helloAction"
+        }
+    ],
+    "actions": [
+        {
+            "name": "hello/helloAction",
+            "action": "\n/** @private */\nfunction main (params) {\n  const msg = 'Hello ' + params.name + ', ' + params.message + '.'\n  return { msg }\n}\n\nmodule.exports.main = main\n",
+            "annotations": {
+                "web-export": true
+            },
+            "params": {
+                "param1": "value1"
+            }
+        },
+        {
+            "name": "hello/goodbyeAction",
+            "action": "\n/** @private */\nfunction main (params) {\n  const msg = 'Goodbye ' + params.name + ', ' + params.message + '.'\n  return { msg }\n}\n\nmodule.exports.main = main\n",
+            "annotations": {
+                "web-export": true
+            },
+            "params": {
+                "param1": "value1"
+            }
+        },
+        {
+            "action": "",
+            "annotations": {
+                "raw-http": false,
+                "web-export": false
+            },
+            "exec": {
+                "components": [
+                  "hello/helloAction",
+                  "hello/goodbyeAction"
+                ],
+                "kind": "sequence"
+            },
+            "name": "hello/my_sequence"
+        },
+        {
+            "action": "",
+            "annotations": {
+                "raw-http": false,
+                "web-export": false
+            },
+            "exec": {
+                "components": [
+                    "/adobeio/shared-validators-v1/headless",
+                    "hello/helloAction"
+                ],
+                "kind": "sequence"
+            },
+            "name": "hello/headless_sequence"
+        }
+    ]
+}

--- a/test/__fixtures__/deploy/pkgparam_manifest_res.json
+++ b/test/__fixtures__/deploy/pkgparam_manifest_res.json
@@ -61,7 +61,6 @@
     "actions": [
         {
             "name": "hello/helloAction",
-            "action": "\n/** @private */\nfunction main (params) {\n  const msg = 'Hello ' + params.name + ', ' + params.message + '.'\n  return { msg }\n}\n\nmodule.exports.main = main\n",
             "annotations": {
                 "web-export": true
             },
@@ -71,7 +70,6 @@
         },
         {
             "name": "hello/goodbyeAction",
-            "action": "\n/** @private */\nfunction main (params) {\n  const msg = 'Goodbye ' + params.name + ', ' + params.message + '.'\n  return { msg }\n}\n\nmodule.exports.main = main\n",
             "annotations": {
                 "web-export": true
             },

--- a/test/__fixtures__/deploy/pkgparam_manifest_res_multi.json
+++ b/test/__fixtures__/deploy/pkgparam_manifest_res_multi.json
@@ -1,0 +1,120 @@
+{
+    "pkgAndDeps": [
+        {
+            "name": "hello",
+            "package": {
+                "parameters": [{
+                  "key": "my-pkg-param",
+                  "value": "pkg-param-value"
+                }]
+              }
+        },
+        {
+            "name": "mypackage",
+            "package": {
+                "binding": {
+                    "namespace": "adobeio",
+                    "name": "oauth"
+                }
+            }
+        },
+        {
+            "name": "hello2",
+            "package": {
+                "parameters": [{
+                    "key": "my-pkg-param2",
+                    "value": "pkg-param-value2"
+                }]
+            }
+        }
+    ],
+    "apis": [
+        {
+            "action": "hello/helloAction",
+            "basepath": "/hello",
+            "name": "hello-world",
+            "operation": "GET",
+            "relpath": "/world",
+            "responsetype": "json"
+        }
+    ],
+    "triggers": [
+        {
+            "name": "hellotrigger",
+            "trigger": {
+                "parameters": [
+                    {
+                        "key": "cron",
+                        "value": "* * * * *"
+                    },
+                    {
+                        "key": "trigger_payload",
+                        "value": "{\"message\": \"hello world!\"}"
+                    }
+                ],
+                "feed": "/whisk.system/alarms/alarm",
+                "annotations":[{
+                    "key": "ann1",
+                    "value": "annvalue"
+                }]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "name": "reportEveryMinute",
+            "trigger": "hellotrigger",
+            "action": "hello/helloAction"
+        }
+    ],
+    "actions": [
+        {
+            "name": "hello/helloAction",
+            "annotations": {
+                "web-export": true
+            },
+            "params": {
+                "param1": "value1"
+            }
+        },
+        {
+            "name": "hello/goodbyeAction",
+            "annotations": {
+                "web-export": true
+            },
+            "params": {
+                "param1": "value1"
+            }
+        },
+        {
+            "action": "",
+            "annotations": {
+                "raw-http": false,
+                "web-export": false
+            },
+            "exec": {
+                "components": [
+                  "hello/helloAction",
+                  "hello/goodbyeAction"
+                ],
+                "kind": "sequence"
+            },
+            "name": "hello/my_sequence"
+        },
+        {
+            "action": "",
+            "annotations": {
+                "raw-http": false,
+                "web-export": false
+            },
+            "exec": {
+                "components": [
+                    "/adobeio/shared-validators-v1/headless",
+                    "hello/helloAction"
+                ],
+                "kind": "sequence"
+            },
+            "name": "hello/headless_sequence"
+        }
+    ]
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -41,6 +41,7 @@ beforeEach(() => {
     'goodbye.js': global.fixtureFile('/deploy/goodbye.js'),
     'basic_manifest.json': global.fixtureFile('/deploy/basic_manifest.json'),
     'basic_manifest_res.json': global.fixtureFile('/deploy/basic_manifest_res.json'),
+    'pkgparam_manifest_res.json': global.fixtureFile('/deploy/pkgparam_manifest_res.json'),
     'basic_manifest_res_namesonly.json': global.fixtureFile('/deploy/basic_manifest_res_namesonly.json')
   }
   global.fakeFileSystem.addJson(json)
@@ -663,14 +664,7 @@ describe('processPackage', () => {
     const packages = JSON.parse(fs.readFileSync('/basic_manifest.json'))
     packages.hello.inputs = { 'my-pkg-param': 'pkg-param-value' }
     const entities = utils.processPackage(packages, {}, {}, {})
-    const res = JSON.parse(fs.readFileSync('/basic_manifest_res.json'))
-    res.pkgAndDeps[0].package = {
-      parameters: [{
-        key: 'my-pkg-param',
-        value: 'pkg-param-value'
-      }]
-    }
-    expect(entities).toMatchObject(res)
+    expect(entities).toMatchObject(JSON.parse(fs.readFileSync('/pkgparam_manifest_res.json')))
   })
 
   test('shared package', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -42,6 +42,7 @@ beforeEach(() => {
     'basic_manifest.json': global.fixtureFile('/deploy/basic_manifest.json'),
     'basic_manifest_res.json': global.fixtureFile('/deploy/basic_manifest_res.json'),
     'pkgparam_manifest_res.json': global.fixtureFile('/deploy/pkgparam_manifest_res.json'),
+    'pkgparam_manifest_res_multi.json': global.fixtureFile('/deploy/pkgparam_manifest_res_multi.json'),
     'basic_manifest_res_namesonly.json': global.fixtureFile('/deploy/basic_manifest_res_namesonly.json')
   }
   global.fakeFileSystem.addJson(json)
@@ -665,6 +666,14 @@ describe('processPackage', () => {
     packages.hello.inputs = { 'my-pkg-param': 'pkg-param-value' }
     const entities = utils.processPackage(packages, {}, {}, {})
     expect(entities).toMatchObject(JSON.parse(fs.readFileSync('/pkgparam_manifest_res.json')))
+  })
+
+  test('basic manifest with package parameters in multiple packages', async () => {
+    const packages = JSON.parse(fs.readFileSync('/basic_manifest.json'))
+    packages.hello.inputs = { 'my-pkg-param': 'pkg-param-value' }
+    packages.hello2 = { inputs: { 'my-pkg-param2': 'pkg-param-value2' } }
+    const entities = utils.processPackage(packages, {}, {}, {})
+    expect(entities).toMatchObject(JSON.parse(fs.readFileSync('/pkgparam_manifest_res_multi.json')))
   })
 
   test('shared package', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -659,6 +659,20 @@ describe('processPackage', () => {
     expect(entities).toMatchObject(JSON.parse(fs.readFileSync('/basic_manifest_res_namesonly.json')))
   })
 
+  test('basic manifest with package parameters', async () => {
+    const packages = JSON.parse(fs.readFileSync('/basic_manifest.json'))
+    packages.hello.inputs = { 'my-pkg-param': 'pkg-param-value' }
+    const entities = utils.processPackage(packages, {}, {}, {})
+    const res = JSON.parse(fs.readFileSync('/basic_manifest_res.json'))
+    res.pkgAndDeps[0].package = {
+      parameters: [{
+        key: 'my-pkg-param',
+        value: 'pkg-param-value'
+      }]
+    }
+    expect(entities).toMatchObject(res)
+  })
+
   test('shared package', async () => {
     const res = utils.processPackage({ pkg1: { public: true } }, {}, {}, {}, false, {})
     expect(res).toEqual(expect.objectContaining({ pkgAndDeps: [{ name: 'pkg1', package: { publish: true } }] }))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding support for package parameters to be defined in the manifest using `inputs` .
```
packages:
  mypkg:
    license: Apache-2.0
    inputs:
      pkgparam1: 'pkgParam1Value'
    actions:
      myaction1:
        function: actions/hello/index.js
        runtime: 'nodejs:12'
        web: true
        annotations:
            require-adobe-auth: false
```

These parameters will be automatically available for any actions within the package.

Fixes https://github.com/adobe/aio-cli-plugin-runtime/issues/200
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
