### PR TITLE
populate runtime action process.env value from local process.env value

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -82,7 +82,10 @@ const getWebpackConfig = async (actionPath, root, tempBuildDir, outBuildFilename
 
   // we have 1 required plugin to make sure is present
   config.plugins = config.plugins || []
-  config.plugins.push(new webpack.DefinePlugin({ WEBPACK_ACTION_BUILD: 'true' }))
+  config.plugins.push(new webpack.DefinePlugin({
+    WEBPACK_ACTION_BUILD: 'true',
+    'process.env.AIO_ENV_IS_STAGE': process.env.AIO_ENV_IS_STAGE || false
+  }))
   // NOTE: no need to make the array unique here, all plugins are different and created via new
 
   aioLogger.debug(`merged webpack config : ${JSON.stringify(config, 0, 2)}`)

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -27,7 +27,7 @@ const getWebpackConfig = async (actionPath, root, tempBuildDir, outBuildFilename
   let parentDir = path.dirname(actionPath)
   const rootParent = path.normalize(path.dirname(root))
   let configPath = null
-  const cli_env = getCliEnv()
+  const cliEnv = getCliEnv()
 
   do {
     const paths = await globby([path.join(parentDir, '*webpack-config.js')])
@@ -86,7 +86,7 @@ const getWebpackConfig = async (actionPath, root, tempBuildDir, outBuildFilename
   config.plugins = config.plugins || []
   config.plugins.push(new webpack.DefinePlugin({
     WEBPACK_ACTION_BUILD: 'true',
-    'process.env.AIO_CLI_ENV': `"${cli_env}"`
+    'process.env.AIO_CLI_ENV': `"${cliEnv}"`
   }))
   // NOTE: no need to make the array unique here, all plugins are different and created via new
 

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -17,6 +17,7 @@ const globby = require('globby')
 const utils = require('./utils')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-runtime:action-builder', { provider: 'debug' })
 const cloneDeep = require('lodash.clonedeep')
+const { getCliEnv } = require('@adobe/aio-lib-env')
 
 const uniqueArr = (items) => {
   return [...new Set(items)]
@@ -26,6 +27,7 @@ const getWebpackConfig = async (actionPath, root, tempBuildDir, outBuildFilename
   let parentDir = path.dirname(actionPath)
   const rootParent = path.normalize(path.dirname(root))
   let configPath = null
+  const cli_env = getCliEnv()
 
   do {
     const paths = await globby([path.join(parentDir, '*webpack-config.js')])
@@ -84,7 +86,7 @@ const getWebpackConfig = async (actionPath, root, tempBuildDir, outBuildFilename
   config.plugins = config.plugins || []
   config.plugins.push(new webpack.DefinePlugin({
     WEBPACK_ACTION_BUILD: 'true',
-    'process.env.AIO_ENV_IS_STAGE': process.env.AIO_ENV_IS_STAGE || false
+    'process.env.AIO_CLI_ENV': `"${cli_env}"`
   }))
   // NOTE: no need to make the array unique here, all plugins are different and created via new
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This pr shows how we can have a stage env value populated all the way through to the action.
Note that the value used are negotiable, I used process.env.AIO_ENV_IS_STAGE as it is a simple boolean value, and we only ever care if we are in stage or not, we don't care what allowed values for env might exist, or what the actual string value is ... just as simple, logical yes or no ...



## Related Issue


[ACNA-1094], [ACNA-1095], [ACNA-1096]




<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

tvm client needs to know which url to load, is it stage or prod ?
file-lib, state-lib might also need this info ...

## How Has This Been Tested?

I added this to an acton I was deploying:

    console.log('AIO_ENV_IS_STAGE=', process.env.AIO_ENV_IS_STAGE)

and put a webpack-config in my action folder ( this requires that the project install webpack as a dependency )

```
const webpack = require('webpack')
module.exports = {
  plugins: [
    new webpack.DefinePlugin({
      'process.env.AIO_ENV_IS_STAGE': process.env.AIO_ENV_IS_STAGE || false
    })
  ]
}
```

Then run:
```
AIO_ENV_IS_STAGE=true aio app run
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
