### PR TITLE
Publish to NPM without bumping the version

### DIFF
--- a/.github/workflows/version-bump-publish.yml
+++ b/.github/workflows/version-bump-publish.yml
@@ -4,8 +4,8 @@ on:
     inputs:
       level:
         description: '<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease'
-        required: true
-        default: 'patch'
+        required: false
+        default: ''
       tag:
         description: 'The tag to publish to.'
         required: false


### PR DESCRIPTION
This is required in cases of npm publish failure due to external reasons.
Same change goes for all our repos and probably https://github.com/adobe/.github/blob/main/workflow-templates/version-bump-publish.yml too.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
