### PR TITLE
Fixed: error handling in case of server validation failure for Log Forwarding API

### DIFF
--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -99,7 +99,7 @@ class LogForwarding {
     }
 
     const fetch = createFetch()
-    return fetch(
+    const res = await fetch(
       this.apiHost + '/runtime/namespaces/' + this.namespace + '/logForwarding',
       {
         method: method,
@@ -110,6 +110,10 @@ class LogForwarding {
         }
       }
     )
+    if (!res.ok) {
+      throw new Error(`${res.status} (${res.statusText}). Error: ${await res.text()}`)
+    }
+    return res
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed error handling in case of failure on server side.

Scenario: server returns response (e.g., API path and creds are correct), but the actual response contains an error rather than successful result.
Before: the result assumed to be success.
After: the result is an error with server error displayed to the user.

Examples of new behavior:

```
aio rt:namespace:log-forwarding:set                                                                                                                   
? select log forwarding destination Azure Log Analytics
? customer ID kjgjkg
? shared key [hidden]
? log type lhh
 ›   Error: failed to update log forwarding configuration: Could not update log forwarding settings for namespace '343284-devxolga-nui': 400 (Bad Request). Error: {"reason":"Validation 
 ›   failed","message":"[Azure HTTP Error: kjgjkg.ods.opinsights.azure.com: Name does not resolve]"}

aio rt:namespace:log-forwarding:set                                                                                                                   
? select log forwarding destination Splunk HEC
? host kjgjgk.com
? port 6767
? index lkhjkh
? hec_token [hidden]
 ›   Error: failed to update log forwarding configuration: Could not update log forwarding settings for namespace '343284-devxolga-nui': 400 (Bad Request). Error: hec token has wrong format. Expected: 
 ›   xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (path = RuntimeResource.configureLogForwardingDestination.arg1.splunk_hec.hec_token, invalidValue = .khkjhjkhjkhkj)
```

The same behavior is for non-interactive commands.

Old behavior with failed request is preserved:
```
aio rt:namespace:log-forwarding:get                                                                                                                   
 ›   Error: failed to get log forwarding configuration: Could not get log forwarding settings for namespace '343284-devxolga-nui': request to 
 ›   https://adobeioruntime.netm/runtime/namespaces/343284-devxolga-nui/logForwarding failed, reason: getaddrinfo ENOTFOUND adobeioruntime.netm
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Automated tests for the library and the plugin
- Manual tests of the plugin. Tested scenarios:
   - `aio rt:namespace:log-forwarding:set` interactive command with `adobe_io_runtime`, `azure_log_analytics` and `aplunk_hec` destinations.
      - with correct and invalid destinations
      - `aio rt:namespace:log-forwarding:get` was used to confirm that configuration was not updated after invalid credentials are provided, and that it was updated after correct credentials are provided
   - `aio rt:namespace:log-forwarding:set:adobe-io-runtime`
   - `aio rt:namespace:log-forwarding:set:azure-log-analytics`, with correct and invalid destinations
   - `aio rt:namespace:log-forwarding:set:splunk-hec`, with correct and invalid destinations
   - `aio rt:namespace:log-forwarding:get`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
