### PR TITLE
Fix: [ACNA-1374]/[ACNA-936] Support for nested input parameters and full env var replacement. 

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -186,11 +186,6 @@ describe('processInputs', () => {
     const res = utils.processInputs({ I: { default: 'am' } }, { })
     expect(res).toEqual({ I: 'am' })
   })
-  test('input = { I : { value: am } }, params = { I : { value: nitpicking } }', () => {
-    // note: is this relevant?
-    const res = utils.processInputs({ I: { value: 'am' } }, { I: { value: 'nitpicking' } })
-    expect(res).toEqual({ I: { value: 'nitpicking' } })
-  })
   test('input = { a : string, one : number, an: integer }, params = { }', () => {
     const res = utils.processInputs({ a: 'string', one: 'number', an: 'integer' }, { })
     expect(res).toEqual({ a: '', one: 0, an: 0 })
@@ -198,7 +193,7 @@ describe('processInputs', () => {
   test('input = { an: $undefEnvVar, a: $definedEnvVar, another: $definedEnvVar, the: ${definedEnvVar}, one: ${ definedEnvVar  } }, params = { a: 123 }', () => {
     process.env.definedEnvVar = 'giraffe'
     const res = utils.processInputs({ an: '$undefEnvVar', a: '$definedEnvVar', another: '$definedEnvVar', the: '${definedEnvVar}', one: '${ definedEnvVar  }' }, { a: 123 })
-    expect(res).toEqual({ a: 123, another: 'giraffe', an: '', the: 'giraffe', one: 'giraffe' })
+    expect(res).toStrictEqual({ a: 123, another: 'giraffe', an: '', the: 'giraffe', one: 'giraffe' })
     delete process.env.definedEnvVar
   })
   test('invalid input returns undefined (coverage)', () => {
@@ -209,11 +204,12 @@ describe('processInputs', () => {
     res = utils.processInputs('string', { a: 123 })
     expect(res).toEqual(undefined)
   })
-  test('nested inputs with default and params, {foo: ${bar}, config: {nestedFoo: {bar}}', () => {
+  test('nested input and params', () => {
     process.env.BAR = 'itWorks'
     process.env.BAR_VAR = 'barVar'
     process.env.FOO = 'fooo'
     const input = {
+      a: 'I will be replaced',
       stuff: '$BAR_VAR $BAR_VAR, ${ BAR_VAR }, $FOO',
       foo: '${BAR}',
       bar: {
@@ -223,10 +219,11 @@ describe('processInputs', () => {
         nestedFoo: {
           extraNested: '${BAR}, $BAR, ${FOO}'
         },
-        a: 'I will be replaced'
+        a: 'I will not be replaced'
       }
     }
     const expectedOutput = {
+      a: 123,
       stuff: 'barVar barVar, barVar, fooo',
       foo: process.env.BAR,
       bar: `${process.env.BAR}, ${process.env.BAR}, ${process.env.FOO}`,
@@ -234,12 +231,14 @@ describe('processInputs', () => {
         nestedFoo: {
           extraNested: `${process.env.BAR}, ${process.env.BAR}, ${process.env.FOO}`
         },
-        a: 123
+        a: 'I will not be replaced'
       }
     }
     const res = utils.processInputs(input, { a: 123 })
-    expect(res).toEqual(expectedOutput)
-    delete process.env.bar
+    expect(res).toStrictEqual(expectedOutput)
+    delete process.env.BAR
+    delete process.env.BAR_VAR
+    delete process.env.FOO
   })
 })
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -186,6 +186,10 @@ describe('processInputs', () => {
     const res = utils.processInputs({ I: { default: 'am' } }, { })
     expect(res).toEqual({ I: 'am' })
   })
+  test('input = { I : { value: am } }, params = { I : nitpicking }', () => {
+    const res = utils.processInputs({ I: { value: 'am' } }, { I: 'nitpicking' })
+    expect(res).toEqual({ I: 'nitpicking' })
+  })
   test('input = { a : string, one : number, an: integer }, params = { }', () => {
     const res = utils.processInputs({ a: 'string', one: 'number', an: 'integer' }, { })
     expect(res).toEqual({ a: '', one: 0, an: 0 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added support for nested input parameters.
Better support for env var replacement of manifest.yml keys.


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-runtime/issues/251
https://github.com/adobe/aio-cli-plugin-app/issues/299

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually & Unit Testing.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
