### PR TITLE
Generic API for Log Forwarding Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ async function sdkTest() {
 <dt><a href="#LogForwarding">LogForwarding</a></dt>
 <dd><p>Log Forwarding management API</p>
 </dd>
+<dt><a href="#LogForwardingLocalDestinationsProvider">LogForwardingLocalDestinationsProvider</a></dt>
+<dd><p>Log Forwarding destination provider</p>
+</dd>
 <dt><a href="#RuntimeAPI">RuntimeAPI</a></dt>
 <dd><p>This class provides methods to call your RuntimeAPI APIs.
 Before calling any method initialize the instance by calling the <code>init</code> method on it
@@ -356,9 +359,12 @@ Log Forwarding management API
 
 * [LogForwarding](#LogForwarding)
     * [.get()](#LogForwarding+get) ⇒ <code>Promise.&lt;\*&gt;</code>
-    * [.setAdobeIoRuntime()](#LogForwarding+setAdobeIoRuntime) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
-    * [.setAzureLogAnalytics(customerId, sharedKey, logType)](#LogForwarding+setAzureLogAnalytics) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
-    * [.setSplunkHec(host, port, index, hecToken)](#LogForwarding+setSplunkHec) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
+    * ~~[.setAdobeIoRuntime()](#LogForwarding+setAdobeIoRuntime) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+    * ~~[.setAzureLogAnalytics(customerId, sharedKey, logType)](#LogForwarding+setAzureLogAnalytics) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+    * ~~[.setSplunkHec(host, port, index, hecToken)](#LogForwarding+setSplunkHec) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+    * [.getSupportedDestinations()](#LogForwarding+getSupportedDestinations) ⇒ <code>Array.&lt;object&gt;</code>
+    * [.getDestinationSettings(destination)](#LogForwarding+getDestinationSettings) ⇒ <code>Array.&lt;object&gt;</code>
+    * [.setDestination(destination, config)](#LogForwarding+setDestination) ⇒ <code>Promise.&lt;\*&gt;</code>
 
 <a name="LogForwarding+get"></a>
 
@@ -369,14 +375,18 @@ Get current Log Forwarding settings
 **Returns**: <code>Promise.&lt;\*&gt;</code> - response from get API  
 <a name="LogForwarding+setAdobeIoRuntime"></a>
 
-### logForwarding.setAdobeIoRuntime() ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
+### ~~logForwarding.setAdobeIoRuntime() ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+***Deprecated***
+
 Set Log Forwarding to Adobe I/O Runtime (default behavior)
 
 **Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
 **Returns**: <code>Promise.&lt;(\*\|undefined)&gt;</code> - response from set API  
 <a name="LogForwarding+setAzureLogAnalytics"></a>
 
-### logForwarding.setAzureLogAnalytics(customerId, sharedKey, logType) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
+### ~~logForwarding.setAzureLogAnalytics(customerId, sharedKey, logType) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+***Deprecated***
+
 Set Log Forwarding to Azure Log Analytics
 
 **Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
@@ -390,7 +400,9 @@ Set Log Forwarding to Azure Log Analytics
 
 <a name="LogForwarding+setSplunkHec"></a>
 
-### logForwarding.setSplunkHec(host, port, index, hecToken) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>
+### ~~logForwarding.setSplunkHec(host, port, index, hecToken) ⇒ <code>Promise.&lt;(\*\|undefined)&gt;</code>~~
+***Deprecated***
+
 Set Log Forwarding to Splunk HEC
 
 **Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
@@ -402,6 +414,68 @@ Set Log Forwarding to Splunk HEC
 | port | <code>string</code> | port |
 | index | <code>string</code> | index |
 | hecToken | <code>string</code> | hec token |
+
+<a name="LogForwarding+getSupportedDestinations"></a>
+
+### logForwarding.getSupportedDestinations() ⇒ <code>Array.&lt;object&gt;</code>
+Get supported destinations
+
+**Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
+**Returns**: <code>Array.&lt;object&gt;</code> - in format: { value: <value>, name: <name> }  
+<a name="LogForwarding+getDestinationSettings"></a>
+
+### logForwarding.getDestinationSettings(destination) ⇒ <code>Array.&lt;object&gt;</code>
+Get destination settings
+
+**Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
+**Returns**: <code>Array.&lt;object&gt;</code> - in format: { name: <name>, message: <message>[, type: <type>] }  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| destination | <code>string</code> | Destination name |
+
+<a name="LogForwarding+setDestination"></a>
+
+### logForwarding.setDestination(destination, config) ⇒ <code>Promise.&lt;\*&gt;</code>
+Configure destination
+
+**Kind**: instance method of [<code>LogForwarding</code>](#LogForwarding)  
+**Returns**: <code>Promise.&lt;\*&gt;</code> - response from set API  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| destination | <code>string</code> | Destination name |
+| config | <code>object</code> | value-pairs of settings, specific to the destination |
+
+<a name="LogForwardingLocalDestinationsProvider"></a>
+
+## LogForwardingLocalDestinationsProvider
+Log Forwarding destination provider
+
+**Kind**: global class  
+
+* [LogForwardingLocalDestinationsProvider](#LogForwardingLocalDestinationsProvider)
+    * [.getSupportedDestinations()](#LogForwardingLocalDestinationsProvider+getSupportedDestinations) ⇒ <code>Array.&lt;object&gt;</code>
+    * [.getDestinationSettings(destination)](#LogForwardingLocalDestinationsProvider+getDestinationSettings) ⇒ <code>Array.&lt;object&gt;</code>
+
+<a name="LogForwardingLocalDestinationsProvider+getSupportedDestinations"></a>
+
+### logForwardingLocalDestinationsProvider.getSupportedDestinations() ⇒ <code>Array.&lt;object&gt;</code>
+Get supported destinations
+
+**Kind**: instance method of [<code>LogForwardingLocalDestinationsProvider</code>](#LogForwardingLocalDestinationsProvider)  
+**Returns**: <code>Array.&lt;object&gt;</code> - in format: { value: <value>, name: <name> }  
+<a name="LogForwardingLocalDestinationsProvider+getDestinationSettings"></a>
+
+### logForwardingLocalDestinationsProvider.getDestinationSettings(destination) ⇒ <code>Array.&lt;object&gt;</code>
+Get destination settings
+
+**Kind**: instance method of [<code>LogForwardingLocalDestinationsProvider</code>](#LogForwardingLocalDestinationsProvider)  
+**Returns**: <code>Array.&lt;object&gt;</code> - in format: { name: <name>, message: <message>[, type: <type>] }  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| destination | <code>string</code> | Destination name |
 
 <a name="RuntimeAPI"></a>
 

--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -15,10 +15,11 @@ const { createFetch } = require('@adobe/aio-lib-core-networking')
  * Log Forwarding management API
  */
 class LogForwarding {
-  constructor (namespace, apiHost, apiKey) {
+  constructor (namespace, apiHost, apiKey, destinationsProvider) {
     this.apiHost = apiHost
     this.auth = apiKey
     this.namespace = namespace
+    this.destinationsProvider = destinationsProvider
   }
 
   /**
@@ -38,6 +39,7 @@ class LogForwarding {
   /**
    * Set Log Forwarding to Adobe I/O Runtime (default behavior)
    *
+   * @deprecated use `setDestination('adobe_io_runtime', {})`
    * @returns {Promise<*|undefined>} response from set API
    */
   async setAdobeIoRuntime () {
@@ -49,6 +51,7 @@ class LogForwarding {
   /**
    * Set Log Forwarding to Azure Log Analytics
    *
+   * @deprecated use `setDestination('azure_log_analytics', {...})`
    * @param {string} customerId customer ID
    * @param {string} sharedKey shared key
    * @param {string} logType log type
@@ -67,6 +70,7 @@ class LogForwarding {
   /**
    * Set Log Forwarding to Splunk HEC
    *
+   * @deprecated use `setDestination('splunk_hec', {...})`
    * @param {string} host host
    * @param {string} port port
    * @param {string} index index
@@ -82,6 +86,44 @@ class LogForwarding {
         hec_token: hecToken
       }
     })
+  }
+
+  /**
+   * Get supported destinations
+   *
+   * @returns {object[]} in format: { value: <value>, name: <name> }
+   */
+  getSupportedDestinations () {
+    return this.destinationsProvider.getSupportedDestinations()
+  }
+
+  /**
+   * Get destination settings
+   *
+   * @param {string} destination Destination name
+   * @returns {object[]} in format: { name: <name>, message: <message>[, type: <type>] }
+   */
+  getDestinationSettings (destination) {
+    return this.destinationsProvider.getDestinationSettings(destination)
+  }
+
+  /**
+   * Configure destination
+   *
+   * @param {string} destination Destination name
+   * @param {object} config value-pairs of settings, specific to the destination
+   * @returns {Promise<*>} response from set API
+   */
+  async setDestination (destination, config) {
+    const data = {
+      [destination]: config
+    }
+    try {
+      const res = await this.request('put', data)
+      return await res.text()
+    } catch (e) {
+      throw new Error(`Could not update log forwarding settings for namespace '${this.namespace}': ${e.message}`)
+    }
   }
 
   async set (data) {

--- a/src/LogForwardingLocalDestinationsProvider.js
+++ b/src/LogForwardingLocalDestinationsProvider.js
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Log Forwarding destination provider
+ */
+class LogForwardingLocalDestinationsProvider {
+  constructor () {
+    this.destinations = {
+      adobe_io_runtime: {
+        name: 'Adobe I/O Runtime',
+        settings: []
+      },
+      azure_log_analytics: {
+        name: 'Azure Log Analytics',
+        settings: [
+          {
+            name: 'customer_id',
+            message: 'customer ID'
+          },
+          {
+            name: 'shared_key',
+            message: 'shared key',
+            type: 'password'
+          },
+          {
+            name: 'log_type',
+            message: 'log type'
+          }
+        ]
+      },
+      splunk_hec: {
+        name: 'Splunk HEC',
+        settings: [
+          {
+            name: 'host',
+            message: 'host'
+          },
+          {
+            name: 'port',
+            message: 'port'
+          },
+          {
+            name: 'index',
+            message: 'index'
+          },
+          {
+            name: 'hec_token',
+            message: 'hec_token',
+            type: 'password'
+          }
+        ]
+      }
+    }
+  }
+
+  /**
+   * Get supported destinations
+   *
+   * @returns {object[]} in format: { value: <value>, name: <name> }
+   */
+  getSupportedDestinations () {
+    return Object.keys(this.destinations).map(k => {
+      return { value: k, name: this.destinations[k].name }
+    })
+  }
+
+  /**
+   * Get destination settings
+   *
+   * @param {string} destination Destination name
+   * @returns {object[]} in format: { name: <name>, message: <message>[, type: <type>] }
+   */
+  getDestinationSettings (destination) {
+    if (this.destinations[destination] === undefined) {
+      throw new Error(`Destination '${destination}' is not supported`)
+    }
+    return this.destinations[destination].settings
+  }
+}
+
+module.exports = LogForwardingLocalDestinationsProvider

--- a/src/RuntimeAPI.js
+++ b/src/RuntimeAPI.js
@@ -16,6 +16,7 @@ const { getProxyForUrl } = require('proxy-from-env')
 const deepCopy = require('lodash.clonedeep')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-runtime:RuntimeAPI', { provider: 'debug', level: process.env.LOG_LEVEL })
 const LogForwarding = require('./LogForwarding')
+const LogForwardingLocalDestinationsProvider = require('./LogForwardingLocalDestinationsProvider')
 
 require('./types.jsdoc') // for VS Code autocomplete
 /* global OpenwhiskOptions, OpenwhiskClient */ // for linter
@@ -80,7 +81,12 @@ class RuntimeAPI {
         }
       }),
       routes: this.ow.routes,
-      logForwarding: new LogForwarding(options.namespace, options.apihost, options.api_key),
+      logForwarding: new LogForwarding(
+        clonedOptions.namespace,
+        clonedOptions.apihost,
+        clonedOptions.api_key,
+        new LogForwardingLocalDestinationsProvider()
+      ),
       initOptions: clonedOptions
     }
   }

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -1,4 +1,5 @@
 const LogForwarding = require('../src/LogForwarding')
+const LogForwardingLocalDestinationsProvider = require('../src/LogForwardingLocalDestinationsProvider')
 const { createFetch } = require('@adobe/aio-lib-core-networking')
 const mockFetch = jest.fn()
 
@@ -24,7 +25,12 @@ const dataFixtures = [
 let logForwarding
 
 beforeEach(async () => {
-  logForwarding = new LogForwarding('some_namespace', 'host', 'key')
+  logForwarding = new LogForwarding(
+    'some_namespace',
+    'host',
+    'key',
+    new LogForwardingLocalDestinationsProvider()
+  )
   createFetch.mockReturnValue(mockFetch)
   mockFetch.mockReset()
 })
@@ -63,7 +69,7 @@ test('get failed on server', async () => {
   await expect(logForwarding.get()).rejects.toThrow("Could not get log forwarding settings for namespace 'some_namespace': 400 (Bad Request). Error: Error")
 })
 
-test.each(dataFixtures)('set %s', async (destination, fnName, input) => {
+test.each(dataFixtures)('set %s (deprecated)', async (destination, fnName, input) => {
   return new Promise(resolve => {
     mockFetch.mockReturnValue(new Promise(resolve => {
       resolve({
@@ -81,7 +87,7 @@ test.each(dataFixtures)('set %s', async (destination, fnName, input) => {
   })
 })
 
-test.each(dataFixtures)('set %s failed', async (destination, fnName, input) => {
+test.each(dataFixtures)('set %s failed (deprecated)', async (destination, fnName, input) => {
   const res = {
     ok: false,
     status: 400,
@@ -93,6 +99,79 @@ test.each(dataFixtures)('set %s failed', async (destination, fnName, input) => {
   await expect(logForwarding[fnName]())
     .rejects
     .toThrow(`Could not update log forwarding settings for namespace 'some_namespace': 400 (Bad Request). Error: Error for ${destination}`)
+})
+
+test('get supported destinations', async () => {
+  return new Promise(resolve => {
+    const res = logForwarding.getSupportedDestinations()
+    expect(res).toEqual(
+      [
+        { value: 'adobe_io_runtime', name: 'Adobe I/O Runtime' },
+        { value: 'azure_log_analytics', name: 'Azure Log Analytics' },
+        { value: 'splunk_hec', name: 'Splunk HEC' }
+      ]
+    )
+    resolve()
+  })
+})
+
+test('get destination settings', async () => {
+  return new Promise(resolve => {
+    const actual = logForwarding.getDestinationSettings('splunk_hec')
+    expect(actual).toEqual([
+      {
+        message: 'host',
+        name: 'host'
+      },
+      {
+        message: 'port',
+        name: 'port'
+      },
+      {
+        message: 'index',
+        name: 'index'
+      },
+      {
+        message: 'hec_token',
+        name: 'hec_token',
+        type: 'password'
+      }
+    ])
+    resolve()
+  })
+})
+
+test('get settings for unsupported destination', async () => {
+  return new Promise(resolve => {
+    expect(() => {
+      logForwarding.getDestinationSettings('unsupported')
+    }).toThrow("Destination 'unsupported' is not supported")
+    resolve()
+  })
+})
+
+test('set destination', async () => {
+  return new Promise(resolve => {
+    mockFetch.mockReturnValue(new Promise(resolve => {
+      resolve({
+        ok: true,
+        text: jest.fn().mockResolvedValue("result for 'destination'")
+      })
+    }))
+    return logForwarding.setDestination('destination', { k: 'v' })
+      .then((res) => {
+        expect(mockFetch).toBeCalledTimes(1)
+        expect(res).toBe("result for 'destination'")
+        assertRequest('put', { destination: { k: 'v' } })
+        resolve()
+      })
+  })
+})
+
+test('set destination failed', async () => {
+  mockFetch.mockRejectedValue(new Error('mocked error'))
+  await expect(logForwarding.setDestination('destination', {}))
+    .rejects.toThrow("Could not update log forwarding settings for namespace 'some_namespace': mocked error")
 })
 
 const assertRequest = (expectedMethod, expectedData) => {

--- a/test/LogForwardingUnderscoreNamespace.test.js
+++ b/test/LogForwardingUnderscoreNamespace.test.js
@@ -1,4 +1,5 @@
 const LogForwarding = require('../src/LogForwarding')
+const LogForwardingLocalDestinationsProvider = require('../src/LogForwardingLocalDestinationsProvider')
 
 const { createFetch } = require('@adobe/aio-lib-core-networking')
 const mockFetch = jest.fn()
@@ -23,7 +24,12 @@ const dataFixtures = [
 let logForwarding
 
 beforeEach(async () => {
-  logForwarding = new LogForwarding('_', 'host', 'key')
+  logForwarding = new LogForwarding(
+    '_',
+    'host',
+    'key',
+    new LogForwardingLocalDestinationsProvider()
+  )
   createFetch.mockReturnValue(mockFetch)
   mockFetch.mockReset()
 })
@@ -32,6 +38,10 @@ test('get for namespace "_" is not supported', async () => {
   await expect(logForwarding.get()).rejects.toThrow("Namespace '_' is not supported by log forwarding management API")
 })
 
-test.each(dataFixtures)('set %s for namespace "_" is not supported', async (destination, fnName, input) => {
+test.each(dataFixtures)('set (deprecated) %s for namespace "_" is not supported', async (destination, fnName, input) => {
   await expect(logForwarding[fnName](...Object.values(input))).rejects.toThrow("Namespace '_' is not supported by log forwarding management API")
+})
+
+test.each(dataFixtures)('set %s for namespace "_" is not supported', async (destination, fnName, input) => {
+  await expect(logForwarding.setDestination(destination, input)).rejects.toThrow("Namespace '_' is not supported by log forwarding management API")
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,6 +29,41 @@ declare class LogForwarding {
      * @returns response from set API
      */
     setSplunkHec(host: string, port: string, index: string, hecToken: string): Promise<any | undefined>;
+    /**
+     * Get supported destinations
+     * @returns in format: { value: <value>, name: <name> }
+     */
+    getSupportedDestinations(): object[];
+    /**
+     * Get destination settings
+     * @param destination - Destination name
+     * @returns in format: { name: <name>, message: <message>[, type: <type>] }
+     */
+    getDestinationSettings(destination: string): object[];
+    /**
+     * Configure destination
+     * @param destination - Destination name
+     * @param config - value-pairs of settings, specific to the destination
+     * @returns response from set API
+     */
+    setDestination(destination: string, config: any): Promise<any>;
+}
+
+/**
+ * Log Forwarding destination provider
+ */
+declare class LogForwardingLocalDestinationsProvider {
+    /**
+     * Get supported destinations
+     * @returns in format: { value: <value>, name: <name> }
+     */
+    getSupportedDestinations(): object[];
+    /**
+     * Get destination settings
+     * @param destination - Destination name
+     * @returns in format: { name: <name>, message: <message>[, type: <type>] }
+     */
+    getDestinationSettings(destination: string): object[];
 }
 
 /**


### PR DESCRIPTION
This allows to set supported log forwarding settings in a single place (currently, it's `src/LogForwardingLocalDestinationsProvider.js`, in the future this can be fetched from Runtime API as such endpoint gets supported). This allows to keep Runtime library and Runtime aio plugin flexible enough to support any new destinations w/o modifying multiple places.

## Description

The task is done in scope of https://github.com/adobe/aio-cli-plugin-app/issues/501 with a reason to avoid modification of 3 places (https://github.com/adobe/aio-lib-runtime, https://github.com/adobe/aio-cli-plugin-runtime, https://github.com/adobe/aio-cli-plugin-app) as destination settings change, and instead limit changes to this repository.

Note: non-interactive commands in https://github.com/adobe/aio-cli-plugin-runtime still don't allow to switch to this model fully, but non-interactive commands (used in https://github.com/adobe/aio-cli-plugin-runtime and in https://github.com/adobe/aio-cli-plugin-app) are now implemented in generic way.

## Related Issue

https://github.com/adobe/aio-cli-plugin-app/issues/501

## Motivation and Context

See Description.

## How Has This Been Tested?

Automated and manual testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
