### PR TITLE
Fixed: log forwarding API requests fails with no protocol in OpenWhisk apihost

### DIFF
--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -17,6 +17,11 @@ const { createFetch } = require('@adobe/aio-lib-core-networking')
 class LogForwarding {
   constructor (namespace, apiHost, apiKey, destinationsProvider) {
     this.apiHost = apiHost
+    // if apihost does not have the protocol, assume HTTPS
+    if (!apiHost.match(/^http(s)?:\/\//)) {
+      this.apiHost = `https://${this.apiHost}`
+    }
+
     this.auth = apiKey
     this.namespace = namespace
     this.destinationsProvider = destinationsProvider

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -5,7 +5,7 @@ const mockFetch = jest.fn()
 
 jest.mock('@adobe/aio-lib-core-networking')
 
-const apiUrl = 'host/runtime/namespaces/some_namespace/logForwarding'
+const apiUrl = 'https://host/runtime/namespaces/some_namespace/logForwarding'
 
 const dataFixtures = [
   ['adobe_io_runtime', 'setAdobeIoRuntime', {}],
@@ -27,12 +27,26 @@ let logForwarding
 beforeEach(async () => {
   logForwarding = new LogForwarding(
     'some_namespace',
-    'host',
+    'https://host',
     'key',
     new LogForwardingLocalDestinationsProvider()
   )
   createFetch.mockReturnValue(mockFetch)
   mockFetch.mockReset()
+})
+
+test('ensure apihost protocol is not duplicated', async () => {
+  expect(logForwarding.apiHost).toEqual('https://host')
+})
+
+test('ensure apihost has protocol', async () => {
+  logForwarding = new LogForwarding(
+    'some_namespace',
+    'host',
+    'key',
+    new LogForwardingLocalDestinationsProvider()
+  )
+  expect(logForwarding.apiHost).toEqual('https://host')
 })
 
 test('get', async () => {


### PR DESCRIPTION
## Description

Fixed an error with API and dependent `aio rt log-forwarding` commands in case OW api host doesn't contain protocol.

## Related Issue

https://github.com/adobe/aio-lib-runtime/issues/89

## Motivation and Context

Fix an issue.

## How Has This Been Tested?

Automated and manual testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
