### PR TITLE
Node 16

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 coverage
 junit.xml
 .env
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
     "globby": "^11.0.1",
     "js-yaml": "^3.14.0",
     "lodash.clonedeep": "^4.5.0",
-    "openwhisk": "^3.21.5",
+    "openwhisk": "^3.21.6",
     "openwhisk-fqn": "0.0.2",
     "proxy-from-env": "^1.1.0",
-    "semver": "^7.3.2",
     "sha1": "^1.1.1",
     "webpack": "^5.26.3"
   },
@@ -56,7 +55,7 @@
     "typescript": "^4.5.2"
   },
   "engines": {
-    "node": "^10 || ^12 || ^14"
+    "node": "^14 || ^16"
   },
   "scripts": {
     "e2e": "jest --config e2e/jest.config.js --runInBand",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1988,7 +1988,7 @@ function validateActionRuntime (action) {
   // sometimes this method is called with 'sequence' which is a different kind of kind than exec.kind which
   // comes from action: runtime: in manifest -jm
   if (action.exec && action.exec.kind && action.exec.kind.toLowerCase().startsWith('nodejs:')) {
-    if (SupportedRuntimes.indexOf(action.exec.kind) < 0) {
+    if (!SupportedRuntimes.includes(action.exec.kind)) {
       throw new Error(`Unsupported node version in action ${action.name}. Supported versions are ${SupportedRuntimes}`)
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,8 +20,8 @@ const fetch = createFetch()
 const globby = require('globby')
 const path = require('path')
 const archiver = require('archiver')
-const semver = require('semver')
-const supportedEngines = require('../package.json').engines
+// this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
+const SupportedRuntimes = ['nodejs:10', 'nodejs:12', 'nodejs:14']
 
 /**
  *
@@ -1984,10 +1984,12 @@ function replacePackagePlaceHolder (config) {
  * @param {object} action action object
  */
 function validateActionRuntime (action) {
+  // I suspect we have an issue here with 2 kinds of kinds ...
+  // sometimes this method is called with 'sequence' which is a different kind of kind than exec.kind which
+  // comes from action: runtime: in manifest -jm
   if (action.exec && action.exec.kind && action.exec.kind.toLowerCase().startsWith('nodejs:')) {
-    const nodeVer = semver.coerce(action.exec.kind.split(':')[1])
-    if (!semver.satisfies(nodeVer, supportedEngines.node)) {
-      throw new Error(`Unsupported node version in action ${action.name}. Supported versions are ${supportedEngines.node}`)
+    if (SupportedRuntimes.indexOf(action.exec.kind) < 0) {
+      throw new Error(`Unsupported node version in action ${action.name}. Supported versions are ${SupportedRuntimes}`)
     }
   }
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2062,10 +2062,8 @@ describe('validateActionRuntime', () => {
   })
 
   test('invalid nodejs version', async () => {
-    const supportedEngines = require('../package.json').engines
-
-    const func = () => utils.validateActionRuntime({ exec: { kind: 'nodejs:16' } })
-    expect(func).toThrowError(`Unsupported node version in action undefined. Supported versions are ${supportedEngines.node}`)
+    const func = () => utils.validateActionRuntime({ exec: { kind: 'nodejs:17' } })
+    expect(func).toThrowError('Unsupported node version')
   })
 
   test('dumpActionsBuiltInfo might catch some errors under unlikely conditions', async () => {


### PR DESCRIPTION
This bumps the required version of node for the lib, and splits out tests which should be testing against supported openwhisk/runtime deployable versions.

This closes #91 
This closes #85 
This closes #82