### PR TITLE
Log Forwarding Set API Returns JSON instead of Text

### DIFF
--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -139,15 +139,7 @@ class LogForwarding {
   async getErrors () {
     try {
       const requestResult = await this.request('get', undefined, '/errors')
-      const result = await requestResult.json()
-      if (result.destination !== undefined && result.errors !== undefined && Array.isArray(result.errors)) {
-        return result
-      } else {
-        return {
-          destination: undefined,
-          errors: []
-        }
-      }
+      return await requestResult.json()
     } catch (e) {
       throw new Error(`Could not get log forwarding errors for namespace '${this.namespace}': ${e.message}`)
     }

--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -125,7 +125,7 @@ class LogForwarding {
     }
     try {
       const res = await this.request('put', data)
-      return await res.text()
+      return await res.json()
     } catch (e) {
       throw new Error(`Could not update log forwarding settings for namespace '${this.namespace}': ${e.message}`)
     }
@@ -156,7 +156,7 @@ class LogForwarding {
   async set (data) {
     try {
       const res = await this.request('put', data)
-      return await res.text()
+      return await res.json()
     } catch (e) {
       throw new Error(`Could not update log forwarding settings for namespace '${this.namespace}': ${e.message}`)
     }

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -85,16 +85,17 @@ test('get failed on server', async () => {
 
 test.each(dataFixtures)('set %s (deprecated)', async (destination, fnName, input) => {
   return new Promise(resolve => {
+    const result = { [destination]: { field: 'data' } }
     mockFetch.mockReturnValue(new Promise(resolve => {
       resolve({
         ok: true,
-        text: jest.fn().mockResolvedValue(`result for ${destination}`)
+        json: jest.fn().mockResolvedValue(result)
       })
     }))
     return logForwarding[fnName](...Object.values(input))
       .then((res) => {
         expect(mockFetch).toBeCalledTimes(1)
-        expect(res).toBe(`result for ${destination}`)
+        expect(res).toBe(result)
         assertRequest('put', { [destination]: input })
         resolve()
       })
@@ -166,16 +167,17 @@ test('get settings for unsupported destination', async () => {
 
 test('set destination', async () => {
   return new Promise(resolve => {
+    const result = { destination: { field: 'data' } }
     mockFetch.mockReturnValue(new Promise(resolve => {
       resolve({
         ok: true,
-        text: jest.fn().mockResolvedValue("result for 'destination'")
+        json: jest.fn().mockResolvedValue(result)
       })
     }))
     return logForwarding.setDestination('destination', { k: 'v' })
       .then((res) => {
         expect(mockFetch).toBeCalledTimes(1)
-        expect(res).toBe("result for 'destination'")
+        expect(res).toBe(result)
         assertRequest('put', { destination: { k: 'v' } })
         resolve()
       })

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -190,51 +190,21 @@ test('set destination failed', async () => {
     .rejects.toThrow("Could not update log forwarding settings for namespace 'some_namespace': mocked error")
 })
 
-test.each([
-  [
-    'errors exist',
-    {
-      destination: 'destination',
-      errors: [
-        'error1',
-        'error2'
-      ]
-    },
-    {
-      destination: 'destination',
-      errors: [
-        'error1',
-        'error2'
-      ]
-    }
-  ],
-  [
-    'no errors',
-    {
-      destination: 'destination',
-      errors: []
-    },
-    {
-      destination: 'destination',
-      errors: []
-    }
-  ],
-  [
-    'empty remote response',
-    {},
-    {
-      destination: undefined,
-      errors: []
-    }
-  ]
-])('get errors (%s)', async (test, remoteResponse, expected) => {
+test('get errors', async () => {
+  const result = {
+    configured_forwarder: 'destination',
+    errors: [
+      'error1',
+      'error2'
+    ]
+  }
   mockFetch.mockReturnValue(new Promise(resolve => {
     resolve({
       ok: true,
-      json: jest.fn().mockResolvedValue(remoteResponse)
+      json: jest.fn().mockResolvedValue(result)
     })
   }))
-  expect(await logForwarding.getErrors()).toEqual(expected)
+  expect(await logForwarding.getErrors()).toEqual(result)
   expect(mockFetch).toBeCalledTimes(1)
   assertRequest('get', undefined, '/errors')
 })


### PR DESCRIPTION
Updated `set` API to return result from Runtime API as JSON.
Updated `errors` API to just return the server response.

## Description

Runtime API for Log Forwarding `PUT` was updated to return actual settings that were stored on the server. The response is JSON. Updated the SDK to reflect this and return JSON instead of text.

## Related Issue

Required for

- https://github.com/adobe/aio-cli-plugin-app/issues/501
- https://github.com/adobe/aio-cli-plugin-runtime/issues/256

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual and auto tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This changes return result of the Log Forwarding API.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
