### PR TITLE
fix: ACNA-1480 - support for concurrentActivations limit key

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1010,8 +1010,10 @@ function createActionObject (fullName, manifestAction) {
     objAction.limits = {
       memory: manifestAction.limits.memorySize || 256,
       logs: manifestAction.limits.logSize || 10,
-      timeout: manifestAction.limits.timeout || 60000,
-      ...concurrencyLimit && { concurrency: concurrencyLimit }
+      timeout: manifestAction.limits.timeout || 60000
+    }
+    if (concurrencyLimit) {
+      objAction.limits.concurrency = concurrencyLimit
     }
   }
   objAction.annotations = returnAnnotations(manifestAction)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1006,15 +1006,13 @@ function createActionObject (fullName, manifestAction) {
   }
 
   if (manifestAction.limits) {
-    const limits = {
+    const concurrencyLimit = manifestAction.limits.concurrentActivations || manifestAction.limits.concurrency
+    objAction.limits = {
       memory: manifestAction.limits.memorySize || 256,
       logs: manifestAction.limits.logSize || 10,
-      timeout: manifestAction.limits.timeout || 60000
+      timeout: manifestAction.limits.timeout || 60000,
+      ...concurrencyLimit && { concurrency: concurrencyLimit }
     }
-    if (manifestAction.limits.concurrency) {
-      limits.concurrency = manifestAction.limits.concurrency
-    }
-    objAction.limits = limits
   }
   objAction.annotations = returnAnnotations(manifestAction)
   return objAction

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -617,6 +617,20 @@ describe('createActionObject', () => {
       name: 'fake'
     }))
   })
+  test('action supported limits', () => {
+    readFileSyncSpy.mockImplementation(() => 'some source code')
+    const res = utils.createActionObject('fake', {
+      function: 'fake.js',
+      runtime: 'something',
+      limits: {
+        memorySize: 1,
+        logSize: 2,
+        timeout: 3,
+        concurrentActivations: 4
+      }
+    })
+    expect(res).toEqual({ action: 'some source code', annotations: { 'raw-http': false, 'web-export': false }, exec: { kind: 'something' }, limits: { logs: 2, memory: 1, timeout: 3, concurrency: 4 }, name: 'fake' })
+  })
 })
 
 describe('deployPackage', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -617,19 +617,44 @@ describe('createActionObject', () => {
       name: 'fake'
     }))
   })
-  test('action supported limits', () => {
-    readFileSyncSpy.mockImplementation(() => 'some source code')
-    const res = utils.createActionObject('fake', {
+
+  describe('action supported limits', () => {
+    const manifestAction = {
       function: 'fake.js',
-      runtime: 'something',
-      limits: {
+      runtime: 'something'
+    }
+    test('action supported limits, concurrentActivations set', () => {
+      manifestAction.limits = {
         memorySize: 1,
         logSize: 2,
         timeout: 3,
         concurrentActivations: 4
       }
+      readFileSyncSpy.mockImplementation(() => 'some source code')
+      const res = utils.createActionObject('fake', manifestAction)
+      expect(res).toEqual({ action: 'some source code', annotations: { 'raw-http': false, 'web-export': false }, exec: { kind: 'something' }, limits: { logs: 2, memory: 1, timeout: 3, concurrency: 4 }, name: 'fake' })
     })
-    expect(res).toEqual({ action: 'some source code', annotations: { 'raw-http': false, 'web-export': false }, exec: { kind: 'something' }, limits: { logs: 2, memory: 1, timeout: 3, concurrency: 4 }, name: 'fake' })
+    test('action supported limits, concurrency set', () => {
+      manifestAction.limits = {
+        memorySize: 1,
+        logSize: 2,
+        timeout: 3,
+        concurrency: 4
+      }
+      readFileSyncSpy.mockImplementation(() => 'some source code')
+      const res = utils.createActionObject('fake', manifestAction)
+      expect(res).toEqual({ action: 'some source code', annotations: { 'raw-http': false, 'web-export': false }, exec: { kind: 'something' }, limits: { logs: 2, memory: 1, timeout: 3, concurrency: 4 }, name: 'fake' })
+    })
+    test('action supported limits, concurrency | concurrentActivations not set', () => {
+      manifestAction.limits = {
+        memorySize: 1,
+        logSize: 2,
+        timeout: 3
+      }
+      readFileSyncSpy.mockImplementation(() => 'some source code')
+      const res = utils.createActionObject('fake', manifestAction)
+      expect(res).toEqual({ action: 'some source code', annotations: { 'raw-http': false, 'web-export': false }, exec: { kind: 'something' }, limits: { logs: 2, memory: 1, timeout: 3 }, name: 'fake' })
+    })
   })
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The manifest spec limits keys we are supporting are:  

- timeout
- memorySize
- logSize
- concurrentActivations

This PR maps, concurrentActivations key to concurrency key. 

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/507

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests
replication steps from the mentioned issue. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
