### PR TITLE
fix: on unsupported runtime kind - apihost is null for deployPackage when validating the action runtime

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1471,11 +1471,12 @@ async function setupAdobeAuth (actions, owOptions, imsOrgId) {
  * @param {string} imsOrgId the IMS Org ID
  */
 async function deployPackage (entities, ow, logger, imsOrgId) {
-  const opts = await ow.actions.client.options
-  const { namespace: ns, apihost } = opts
+  const actionOpts = await ow.actions.client.options
+  const ns = actionOpts.namespace
+  const { apihost } = ow.initOptions
 
   /* this is a temporary workaround to setup Adobe auth dependencies */
-  await setupAdobeAuth(entities.actions, opts, imsOrgId)
+  await setupAdobeAuth(entities.actions, actionOpts, imsOrgId)
 
   for (const pkg of entities.pkgAndDeps) {
     logger(`Info: Deploying package [${pkg.name}]...`)

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -36,6 +36,7 @@ const owPackageDel = 'packages.delete'
 const owRulesDel = 'rules.delete'
 const owTriggerDel = 'triggers.delete'
 const owAPIDel = 'routes.delete'
+const owInitOptions = 'initOptions'
 
 const libEnv = require('@adobe/aio-lib-env')
 const { STAGE_ENV, PROD_ENV } = jest.requireActual('@adobe/aio-lib-env')
@@ -669,6 +670,7 @@ describe('deployPackage', () => {
     const cmdAPI = ow.mockResolved(owAPI, '')
     const cmdTrigger = ow.mockResolved(owTriggers, '')
     const cmdRule = ow.mockResolved(owRules, '')
+    ow.mockResolvedProperty(owInitOptions, {})
     ow.mockResolvedProperty('actions.client.options', { apiKey: 'my-key', namespace: 'my-namespace' })
 
     mockFetch.mockResolvedValue({
@@ -696,8 +698,15 @@ describe('deployPackage', () => {
   test('basic manifest - unsupported kind', async () => {
     const imsOrgId = 'MyIMSOrgId'
     const mockLogger = jest.fn()
-    const owOptions = { apiKey: 'my-key', namespace: 'my-namespace', apihost: 'https://adobeio.adobeioruntime.net' }
-    ow.mockResolvedProperty('actions.client.options', owOptions)
+    const actionOptions = {
+      apiKey: 'my-key',
+      namespace: 'my-namespace'
+    }
+    const initOptions = {
+      apihost: 'https://adobeio.adobeioruntime.net'
+    }
+    ow.mockResolvedProperty('actions.client.options', actionOptions)
+    ow.mockResolvedProperty(owInitOptions, initOptions)
 
     const result = {
       runtimes: {
@@ -714,11 +723,11 @@ describe('deployPackage', () => {
     })
 
     const supportedClientRuntimes = ['nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16']
-    const supportedServerRuntimes = await utils.getSupportedServerRuntimes(owOptions.apihost)
+    const supportedServerRuntimes = await utils.getSupportedServerRuntimes(initOptions.apihost)
 
     await expect(() =>
       utils.deployPackage(JSON.parse(fs.readFileSync('/basic_manifest_unsupported_kind.json')), ow, mockLogger, imsOrgId)
-    ).rejects.toThrow(`Unsupported node version 'nodejs:8' in action hello/helloAction. Supported versions are ${supportedClientRuntimes}. Supported runtimes on ${owOptions.apihost}: ${supportedServerRuntimes}`)
+    ).rejects.toThrow(`Unsupported node version 'nodejs:8' in action hello/helloAction. Supported versions are ${supportedClientRuntimes}. Supported runtimes on ${initOptions.apihost}: ${supportedServerRuntimes}`)
   })
 
   test('basic manifest (fetch error)', async () => {
@@ -726,6 +735,7 @@ describe('deployPackage', () => {
     const imsOrgId = 'MyIMSOrgId'
     const mockLogger = jest.fn()
     ow.mockResolvedProperty('actions.client.options', { apiKey: 'my-key', namespace: 'my-namespace' })
+    ow.mockResolvedProperty(owInitOptions, {})
 
     const res = {
       ok: false,
@@ -741,6 +751,7 @@ describe('deployPackage', () => {
   test('basic manifest (no IMS Org Id)', async () => {
     // this test is specific to the tmp implementation of the require-adobe-annotation
     const mockLogger = jest.fn()
+    ow.mockResolvedProperty(owInitOptions, {})
 
     await expect(utils.deployPackage(JSON.parse(fs.readFileSync('/basic_manifest_res.json')), ow, mockLogger, null))
       .rejects.toThrowError(new Error('imsOrgId must be defined when using the Adobe headless auth validator'))
@@ -1124,6 +1135,7 @@ describe('syncProject', () => {
     ow.mockResolved('actions.list', [])
     ow.mockResolved('triggers.list', [])
     ow.mockResolved('rules.list', [])
+    ow.mockResolvedProperty(owInitOptions, {})
 
     const resultObject = {
       annotations: [


### PR DESCRIPTION
## Motivation and Context

The error only occurs on an invalid action runtime kind (e.g. `nodejs:8`) specified in the manifest, with v4.2.0, because of a null apihost.

To get a definitive apihost, we need to use the `initOptions` property of the Openwhisk object that is passed around: https://github.com/adobe/aio-lib-runtime/blob/30fdb960c6cc35fb22d8559a3ebbc6f35efaf6e6/src/RuntimeAPI.js#L90

Exception in the error message:
```
❯ aio app deploy
✔ Built 1 action(s) for 'dx/excshell/1'
✔ Building web assets for 'dx/excshell/1'
✖ Deploying actions for 'dx/excshell/1'
 ›   Error: Only absolute URLs are supported
```

## How Has This Been Tested?

1. npm test
2. npm link this branch into @adobe/aio-cli-plugin-app repo folder
3. `aio plugins link` the repo from step 2. above
4. in your project, modify an action to have `nodejs:8` as a kind in the `app.config.yaml`
5. `aio app deploy`

Expected error message:
```
❯ aio app deploy
✔ Built 1 action(s) for 'dx/excshell/1'
✔ Building web assets for 'dx/excshell/1'
✖ Deploying actions for 'dx/excshell/1'
 ›   Error: Unsupported node version 'nodejs:8' in action dx-excshell-1/generic. Supported versions are
 ›   nodejs:10,nodejs:12,nodejs:14,nodejs:16. Supported runtimes on https://adobeioruntime.net:
 ›   nodejs:10,nodejs:12,nodejs:14,nodejs:16
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
