### PR TITLE
Memory limits follow documentation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1011,7 +1011,7 @@ function createActionObject (fullName, manifestAction) {
   if (manifestAction.limits) {
     const concurrencyLimit = manifestAction.limits.concurrentActivations || manifestAction.limits.concurrency
     objAction.limits = {
-      memory: manifestAction.limits.memorySize || 256,
+      memory: manifestAction.limits.memorySize || manifestAction.limits.memory || 256,
       logs: manifestAction.limits.logSize || 10,
       timeout: manifestAction.limits.timeout || 60000
     }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -626,6 +626,14 @@ describe('createActionObject', () => {
       function: 'fake.js',
       runtime: 'something'
     }
+    test('action supported limits alternative name memory', () => {
+      manifestAction.limits = {
+        memory: 1
+      }
+      readFileSyncSpy.mockImplementation(() => 'some source code')
+      const res = utils.createActionObject('fake', manifestAction)
+      expect(res.limits.memory).toEqual(1)
+    })
     test('action supported limits, concurrentActivations set', () => {
       manifestAction.limits = {
         memorySize: 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adobe Documentation state that memory limits should be configured as follow in the `app.config.yaml`

```
application:
  actions: actions
  web: web-src
  runtimeManifest:
    packages:
      mypackage:
        actions:
          myactions:
            function: actions/myaction.js
            runtime: 'nodejs:14'
            limits:
              memory: 512
```

Currently the code only looks for property `memorySize` and not `memory`

[Documentation 1](https://developer.adobe.com/app-builder/docs/guides/appbuilder-configuration/#runtime-manifest)

[Documentation 2](https://developer.adobe.com/runtime/docs/guides/using/system_settings/)

## Related Issue

#105 

## Motivation and Context

The behaviour difference has been found by a customer here : https://experienceleaguecommunities.adobe.com/t5/project-firefly-questions/can-t-change-action-memory-limit/td-p/454197

## How Has This Been Tested?

- Automated tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
