### PR TITLE
fix: update e2e tests for triggers, trigger with feed (unique names)

### DIFF
--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -201,26 +201,52 @@ describe('print logs', () => {
   })
 })
 
-test('triggers', async () => {
-  // Delete non existing trigger
-  const call = sdkClient.triggers.delete({ name: 'e2eTrigger' })
-  await expect(call).rejects.toThrow('The requested resource does not exist')
+test('delete non-existing trigger', async () => {
+  const now = new Date()
+  const triggerName = `e2eTrigger${now.getTime()}`
 
-  // Create
-  expect(await sdkClient.triggers.create({ name: 'e2eTrigger' })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1' }))
-  // Get
-  expect(await sdkClient.triggers.get({ name: 'e2eTrigger' })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1' }))
-  // Delete
-  expect(await sdkClient.triggers.delete({ name: 'e2eTrigger' })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1' }))
+  // Delete non existing trigger
+  const call = sdkClient.triggers.delete({ name: triggerName })
+  await expect(call).rejects.toThrow('The requested resource does not exist')
 })
 
-test('triggers with feed', async () => {
+test('basic trigger', async () => {
+  const now = new Date()
+  const triggerName = `e2eTrigger${now.getTime()}`
+
   // Create
-  expect(await sdkClient.triggers.create({ name: 'e2eTrigger', trigger: { feed: '/whisk.system/alarms/alarm', parameters: [{ key: 'cron', value: '* * * * *' }] } })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1', annotations: expect.arrayContaining([expect.objectContaining({ key: 'feed' })]) }))
+  expect(await sdkClient.triggers.create({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
   // Get
-  expect(await sdkClient.triggers.get({ name: 'e2eTrigger' })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1' }))
+  expect(await sdkClient.triggers.get({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
   // Delete
-  expect(await sdkClient.triggers.delete({ name: 'e2eTrigger' })).toEqual(expect.objectContaining({ name: 'e2eTrigger', version: '0.0.1' }))
+  expect(await sdkClient.triggers.delete({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
+})
+
+test('trigger with feed /whisk.system/alarms/alarm', async () => {
+  const now = new Date()
+  const triggerName = `e2eTrigger${now.getTime()}`
+
+  // Create
+  expect(await sdkClient.triggers.create({ name: triggerName, trigger: { feed: '/whisk.system/alarms/alarm', parameters: [{ key: 'cron', value: '* * * * *' }] } })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1', annotations: expect.arrayContaining([expect.objectContaining({ key: 'feed' })]) }))
+  // Get
+  expect(await sdkClient.triggers.get({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
+  // Delete
+  expect(await sdkClient.triggers.delete({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
+})
+
+test('trigger with feed /whisk.system/alarms/once', async () => {
+  const now = new Date()
+  const triggerName = `e2eTrigger${now.getTime()}`
+
+  // add 1 day. "now" is 1 day later. need this for the future alarm
+  now.setDate(now.getDate() + 1)
+
+  // Create
+  expect(await sdkClient.triggers.create({ name: triggerName, trigger: { feed: '/whisk.system/alarms/once', parameters: [{ key: 'date', value: now.toISOString() }] } })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1', annotations: expect.arrayContaining([expect.objectContaining({ key: 'feed' })]) }))
+  // Get
+  expect(await sdkClient.triggers.get({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
+  // Delete
+  expect(await sdkClient.triggers.delete({ name: triggerName })).toEqual(expect.objectContaining({ name: triggerName, version: '0.0.1' }))
 })
 
 describe('filter manifest based on built actions', () => {


### PR DESCRIPTION
- Improve e2e tests especially if there was a failure (on delete), by randomizing trigger names.
- added test for `/whisk.system/alarm/once`

## How Has This Been Tested?

npm run e2e

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
