### PR TITLE
fix: env vars with hyphens are not processed properly

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -692,7 +692,7 @@ function replaceIfEnvKey (inputString) {
   let match
   let output = inputString
   // eslint-disable-next-line prefer-regex-literals
-  const envKeyMatch = RegExp(/(\${|\${ +|\$)\w+( +}|}|)/, 'g')
+  const envKeyMatch = RegExp(/(\${|\${ +|\$)[a-zA-Z0-9_-]+( +}|}|)/, 'g')
   while ((match = envKeyMatch.exec(inputString)) !== null) {
     // eslint-disable-next-line no-param-reassign
     output = output.replace(match[0], process.env[getEnvKey(match[0])] || '')

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -222,8 +222,11 @@ describe('processInputs', () => {
     process.env.BAR = 'itWorks'
     process.env.BAR_VAR = 'barVar'
     process.env.FOO = 'fooo'
+    process.env['AIO_my-tech-id_from_org'] = 'my-tech-account-id'
+
     const input = {
       a: 'I will be replaced',
+      techId: '$AIO_my-tech-id_from_org',
       stuff: '$BAR_VAR $BAR_VAR, ${ BAR_VAR }, $FOO',
       foo: '${BAR}',
       bar: {
@@ -238,6 +241,7 @@ describe('processInputs', () => {
     }
     const expectedOutput = {
       a: 123,
+      techId: 'my-tech-account-id',
       stuff: 'barVar barVar, barVar, fooo',
       foo: process.env.BAR,
       bar: `${process.env.BAR}, ${process.env.BAR}, ${process.env.FOO}`,


### PR DESCRIPTION
old regex: https://regex101.com/r/sBfXak/1
new regex: https://regex101.com/r/dOa3sT/1

Closes #139 

- Replaced `\w+` with `[a-zA-Z0-9_-]+`  (`\w` is equivalent to `[a-zA-Z0-9_]`)
- This can be `[\w-]+` as well, but I wanted to be explicit.

## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
