### PR TITLE
fix: including files sometimes breaks actions

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -187,7 +187,8 @@ const prepareToBuildAction = async (action, root, dist) => {
     contentHash = actionFileStats.mtime.valueOf()
     buildHash = { [zipFileName]: contentHash }
   } else {
-    [tempActionName] = await fs.readdir(tempBuildDir) // eg: index.25d8f992944c60aa2e62.js
+    const tempDirContents = await fs.readdir(tempBuildDir)
+    tempActionName = tempDirContents.find(file => file.match(/index\.([A-Za-z0-9]+)\.js/g)) // eg: index.25d8f992944c60aa2e62.js
     contentHash = tempActionName && tempActionName.split('.')[1]
     buildHash = { [zipFileName]: contentHash }
   }

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -320,7 +320,7 @@ global.sampleAppIncludesConfig = {
           function: 'actions/action.js',
           web: 'yes',
           runtime: 'nodejs:12',
-          include: [['*.txt', 'text/']]
+          include: [['*.txt', 'app/']]
         }
       }
     }


### PR DESCRIPTION
In the action manifest, if you include a file into a directory that starts with a letter alphabetically higher than i, the action will fail to initialize because the build dir doesn't get organized correctly and the action zip gets uploaded without an index.js

Example: 
```
application:
  actions: actions
  runtimeManifest:
    packages:
      new-app-14:
        license: Apache-2.0
        actions:
          generic:
            function: actions/generic/index.js
            include: 
              - ['./test/generic.test.js', 'common/']   <---- c > i
            web: 'yes'
            runtime: nodejs:16
            inputs:
              LOG_LEVEL: debug
            annotations:
              final: true
```

Deployed action to test: https://53444-mgtestservices-stage.adobeioruntime.net/api/v1/web/new-app-14/generic

## Description

This PR proposes a quick fix to use a regex to find the hashed action index.js file 

## How Has This Been Tested?

Locally linked aio-lib-runtime 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
