### PR TITLE
Send connection: keep-alive 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1484,7 +1484,7 @@ async function deployPackage (entities, ow, logger, imsOrgId) {
       logger(`Info: Skipped creating package [${pkg.name}] because it is a reserved package.`)
     } else {
       logger(`Info: Deploying package [${pkg.name}]...`)
-      await ow.packages.update(pkg)
+      await ow.packages.update({ connection: 'keep-alive', ...pkg })
       logger(`Info: package [${pkg.name}] has been successfully deployed.\n`)
     }
   }
@@ -1522,7 +1522,7 @@ async function deployPackage (entities, ow, logger, imsOrgId) {
       retAction.name = retAction.name.substring(`${DEFAULT_PACKAGE_RESERVED_NAME}/`.length)
     }
     logger(`Info: Deploying action [${retAction.name}]...`)
-    await ow.actions.update(retAction)
+    await ow.actions.update({ connection: 'keep-alive', ...retAction })
     logger(`Info: action [${retAction.name}] has been successfully deployed.\n`)
   }
 
@@ -1534,13 +1534,13 @@ async function deployPackage (entities, ow, logger, imsOrgId) {
   }
   for (const trigger of entities.triggers) {
     logger(`Info: Deploying trigger [${trigger.name}]...`)
-    await ow.triggers.update(trigger)
+    await ow.triggers.update({ connection: 'keep-alive', ...trigger })
     logger(`Info: trigger [${trigger.name}] has been successfully deployed.\n`)
   }
   for (const rule of entities.rules) {
     logger(`Info: Deploying rule [${rule.name}]...`)
     rule.action = `/${ns}/${rule.action}`
-    await ow.rules.update(rule)
+    await ow.rules.update({ connection: 'keep-alive', ...rule })
     logger(`Info: rule [${rule.name}] has been successfully deployed.\n`)
   }
   logger('Success: Deployment completed successfully.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 'connection: keep-alive' to every call to update package|action|rule|trigger.
This addresses an issue where the default values of headers 'connection: close' causes lengthy deploy operations to hang/fail in some environments.

This value is picked up by openwhisk-client-js, and passed through to needle.  No deeper change is required, although we will still be looking to move openwhisk-client-js to a newer release of needle which has some other fixes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
