### PR TITLE
feat: support nodejs:20 kind

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ const globby = require('globby')
 const path = require('path')
 const archiver = require('archiver')
 // this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
-const SupportedRuntimes = ['sequence', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18']
+const SupportedRuntimes = ['sequence', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20']
 const DEFAULT_PACKAGE_RESERVED_NAME = 'default'
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ const globby = require('globby')
 const path = require('path')
 const archiver = require('archiver')
 // this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
-const SupportedRuntimes = ['sequence', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20']
+const SupportedRuntimes = ['sequence', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20']
 const DEFAULT_PACKAGE_RESERVED_NAME = 'default'
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2241,8 +2241,6 @@ describe('validateActionRuntime', () => {
     expect(() => utils.validateActionRuntime({ exec: { kind: 'NODEJS:14' } })).toThrow('Unsupported node version')
   })
   test('invalid nodejs version', () => {
-    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:10' } })).toThrow('Unsupported node version')
-    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:12' } })).toThrow('Unsupported node version')
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:17' } })).toThrow('Unsupported node version')
   })
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2268,11 +2268,10 @@ describe('validateActionRuntime', () => {
   })
 
   test('all good', async () => {
-    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:10' } })).not.toThrow()
-    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:12' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:14' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:16' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:18' } })).not.toThrow()
+    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:20' } })).not.toThrow()
   })
   test('no exec', () => {
     expect(utils.validateActionRuntime({})).toBeUndefined()
@@ -2287,6 +2286,8 @@ describe('validateActionRuntime', () => {
     expect(() => utils.validateActionRuntime({ exec: { kind: 'NODEJS:14' } })).toThrow('Unsupported node version')
   })
   test('invalid nodejs version', () => {
+    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:10' } })).toThrow('Unsupported node version')
+    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:12' } })).toThrow('Unsupported node version')
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:17' } })).toThrow('Unsupported node version')
   })
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2223,6 +2223,8 @@ describe('validateActionRuntime', () => {
   })
 
   test('all good', async () => {
+    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:10' } })).not.toThrow()
+    expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:12' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:14' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:16' } })).not.toThrow()
     expect(() => utils.validateActionRuntime({ exec: { kind: 'nodejs:18' } })).not.toThrow()


### PR DESCRIPTION
Note that due to https://github.com/adobe/aio-lib-runtime/pull/138 we do a server check, and since the server as of now supports `nodejs:20`, `nodejs:10`, and `nodejs:12`, it will not error out but will debug log a mismatch (instead of throwing an exception - this is so the client code is not the gatekeeper).

note: node-10 and node-12 will still be supported and will be removed at a later date according to our deprecation roadmap.

## How Has This Been Tested?

- npm test
- manual tests pending

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
