### PR TITLE
Fix: stop setting ims org to state lib for dead validator

### DIFF
--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -195,8 +195,12 @@ async function deployWsk (scriptConfig, manifestContent, logFunc, filterEntities
   // note we must filter before processPackage, as it expect all built actions to be there
   const entities = utils.processPackage(packages, {}, {}, {}, false, owOptions)
 
-  /* BEGIN temporary workaround for handling require-adobe-auth */
-  // Note this is a tmp workaround and should be removed once the app-registry validator can be used for headless applications
+  // Note1: utils.processPackage sets the headless-v2 validator for all
+  //   require-adobe-auth annotated actions. Here, we have the context on whether
+  //   an app has a frontend or not.
+  // Note2: validator app-registry = headless-v2,
+  //   both actually validate against app-registry. However, keeping them separate
+  //   gives us the flexibility of updating one and not the other if required in the future.
   if (scriptConfig.app.hasFrontend && Array.isArray(entities.actions)) {
     const { getCliEnv, DEFAULT_ENV, PROD_ENV, STAGE_ENV } = require('@adobe/aio-lib-env')
     const env = getCliEnv() || DEFAULT_ENV
@@ -221,7 +225,7 @@ async function deployWsk (scriptConfig, manifestContent, logFunc, filterEntities
       }
     })
   }
-  /* END temporary workaround */
+
   // do the deployment, manifestPath and manifestContent needed for creating a project hash
   await utils.syncProject(packageName, manifestPath, manifestContent, entities, ow, logFunc, scriptConfig.imsOrgId, deleteOldEntities)
   return entities

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -701,15 +701,6 @@ describe('deployPackage', () => {
     expect(cmdAPI).toHaveBeenCalled()
     expect(cmdTrigger).toHaveBeenCalled()
     expect(cmdRule).toHaveBeenCalled()
-
-    // this assertion is specific to the tmp implementation of the require-adobe-annotation
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://adobeio.adobeioruntime.net/api/v1/web/state/put',
-      {
-        body: '{"namespace":"my-namespace","key":"__aio","value":{"project":{"org":{"ims_org_id":"MyIMSOrgId"}}},"ttl":-1}',
-        headers: { Authorization: 'Basic bXkta2V5', 'Content-Type': 'application/json' },
-        method: 'post'
-      })
   })
 
   test('simple manifest (default package)', async () => {
@@ -733,15 +724,6 @@ describe('deployPackage', () => {
     expect(cmdAPI).not.toHaveBeenCalled()
     expect(cmdTrigger).not.toHaveBeenCalled()
     expect(cmdRule).not.toHaveBeenCalled()
-
-    // this assertion is specific to the tmp implementation of the require-adobe-annotation
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://adobeio.adobeioruntime.net/api/v1/web/state/put',
-      {
-        body: '{"namespace":"my-namespace","key":"__aio","value":{"project":{"org":{"ims_org_id":"MyIMSOrgId"}}},"ttl":-1}',
-        headers: { Authorization: 'Basic bXkta2V5', 'Content-Type': 'application/json' },
-        method: 'post'
-      })
   })
 
   test('basic manifest - unsupported kind', async () => {
@@ -806,33 +788,6 @@ describe('deployPackage', () => {
     await expect(() =>
       utils.deployPackage(JSON.parse(fs.readFileSync('/basic_manifest_unsupported_kind.json')), ow, mockLogger, imsOrgId)
     ).not.toThrow()
-  })
-
-  test('basic manifest (fetch error)', async () => {
-    // this test is specific to the tmp implementation of the require-adobe-annotation
-    const imsOrgId = 'MyIMSOrgId'
-    const mockLogger = jest.fn()
-    ow.mockResolvedProperty('actions.client.options', { apiKey: 'my-key', namespace: 'my-namespace' })
-    ow.mockResolvedProperty(owInitOptions, {})
-
-    const res = {
-      ok: false,
-      status: 403,
-      json: jest.fn()
-    }
-    mockFetch.mockResolvedValue(res)
-
-    await expect(utils.deployPackage(JSON.parse(fs.readFileSync('/basic_manifest_res.json')), ow, mockLogger, imsOrgId))
-      .rejects.toThrow(`failed setting ims_org_id=${imsOrgId} into state lib, received status=${res.status}, please make sure your runtime credentials are correct`)
-  })
-
-  test('basic manifest (no IMS Org Id)', async () => {
-    // this test is specific to the tmp implementation of the require-adobe-annotation
-    const mockLogger = jest.fn()
-    ow.mockResolvedProperty(owInitOptions, {})
-
-    await expect(utils.deployPackage(JSON.parse(fs.readFileSync('/basic_manifest_res.json')), ow, mockLogger, null))
-      .rejects.toThrow(new Error('imsOrgId must be defined when using the Adobe headless auth validator'))
   })
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix for #166. This code can be safely deleted now, it was kept as a strategy to rollback to the headless-v1 validator in 2021 see https://github.com/adobe/aio-lib-runtime/pull/65

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
