### PR TITLE
Enable deployment of blackboxes via docker manifest property

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ const globby = require('globby')
 const path = require('path')
 const archiver = require('archiver')
 // this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
-const SupportedRuntimes = ['sequence', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20']
+const SupportedRuntimes = ['sequence', 'blackbox', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20']
 const DEFAULT_PACKAGE_RESERVED_NAME = 'default'
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- When deploying actions, `aio` checks whether kind is supported by cli, and if not double-checks via the API [1].
- Even when blackboxes are enabled, `aio` prevents deployment because blackbox is not returned in supported kinds.
- We fix this by adding blackbox kind `SupportedRuntimes`

[1]
https://github.com/adobe/aio-lib-runtime/blob/e8815561e7d7e06e75e8f4d8cc6ef69da12fb7d2/src/utils.js#L1494

<!--- Describe your changes in detail -->

## Related Issue

adobe/aio-cli-plugin-app#740

I originally opened adobe/aio-cli-plugin-app#739 but this change seems more correct.

## Motivation and Context

I was developing a blackbox image locally before I had access to feature. Each time the actions are redeployed on code change I also have to rerun `wsk action update ... --docker ...` to update the container, but this seams unnecessary as the manifest already supports this.

Same issue found when I got production blackbox access.

## How Has This Been Tested?

This has been tested locally by monkeypatching these changes in local node_modules and successfully deploying a blackbox to both my local openwhisk and production cloud using the `docker` manifest property only.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
