### PR TITLE
fix: use user-defined dist folder for last-built-actions.json

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -301,7 +301,7 @@ const buildActions = async (config, filterActions, skipCheck = false) => {
   // clear out dist dir
   fs.emptyDirSync(distFolder)
   const toBuildList = []
-  const lastBuiltActionsPath = path.join(config.root, 'dist', 'last-built-actions.json')
+  const lastBuiltActionsPath = path.join(config.root, distFolder, 'last-built-actions.json')
   for (const [pkgName, pkg] of Object.entries(modifiedConfig.manifest.full.packages)) {
     const actionsToBuild = Object.entries(pkg.actions || {})
     // build all sequentially (todo make bundler execution parallel)

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -186,7 +186,7 @@ describe('build by zipping js action folder', () => {
   test('full config', async () => {
     setupFs({ addActionFile: true })
 
-    const lastBuiltActionsFile = path.join(config.root, 'dist', 'last-built-actions.json')
+    const lastBuiltActionsFile = path.join(config.root, config.actions.dist, 'last-built-actions.json')
     webpackMock.run.mockImplementation(cb => {
       global.fakeFileSystem.addJson({
         [lastBuiltActionsFile]: '{}'
@@ -221,7 +221,7 @@ describe('build by bundling js action file with webpack', () => {
       // fake the build files
       global.fakeFileSystem.addJson({
         '/dist/actions/action.tmp.js': 'fake',
-        'dist/actions/last-built-actions.json': 'fake'
+        'dist/actions/last-built-actions.json': '{}'
       })
       cb(null, webpackStatsMock)
     })


### PR DESCRIPTION
## Description

Fix hardcoded "dist" folder for 'last-built-actions.json'.

## Related Issue

I suspect there are a few more of these, e.g. SSL certs, log forwarding SHA, etc.

## Motivation and Context

app.manifest.yaml allows for custom `dist` folder but not all part of tool respect it.

## How Has This Been Tested?

- unit tests
- hot patch + blackbox test: `DEBUG=@adobe/aio-lib-runtime* npm run build`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
