### PR TITLE
feat: add emptyDist param to buildActions

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -285,7 +285,7 @@ const zipActions = async (buildsList, lastBuildsPath, distFolder, skipCheck) => 
   return builtList
 }
 
-const buildActions = async (config, filterActions, skipCheck = false) => {
+const buildActions = async (config, filterActions, skipCheck = false, emptyDist = true) => {
   if (!config.app.hasBackend) {
     throw new Error('cannot build actions, app has no backend')
   }
@@ -299,7 +299,9 @@ const buildActions = async (config, filterActions, skipCheck = false) => {
   const distFolder = config.actions.dist
 
   // clear out dist dir
-  fs.emptyDirSync(distFolder)
+  if (emptyDist) {
+    fs.emptyDirSync(distFolder)
+  }
   const toBuildList = []
   const lastBuiltActionsPath = path.join(config.root, 'dist', 'last-built-actions.json')
   for (const [pkgName, pkg] of Object.entries(modifiedConfig.manifest.full.packages)) {

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -53,6 +53,7 @@ beforeEach(() => {
 
   execa.mockReset()
   utils.zip.mockReset()
+  fs.emptyDirSync = jest.fn()
 })
 
 describe('build by zipping js action folder', () => {
@@ -1154,6 +1155,20 @@ test('should not zip files if the action was built before (skipCheck=false)', as
   utils.actionBuiltBefore = jest.fn(() => true)
   await buildActions(config, ['action'], false)
   expect(utils.zip).not.toHaveBeenCalled()
+})
+
+test('should not delete dist folder when emptyDist=false', async () => {
+  addSampleAppFiles()
+  const config = deepClone(global.sampleAppConfig)
+  await buildActions(config, ['action'], false /* skipCheck */, false /* emptyDist */)
+  expect(fs.emptyDirSync).not.toHaveBeenCalled()
+})
+
+test('should delete dist folder when emptyDist=true', async () => {
+  addSampleAppFiles()
+  const config = deepClone(global.sampleAppConfig)
+  await buildActions(config, ['action'], false /* skipCheck */, true /* emptyDist */)
+  expect(fs.emptyDirSync).toHaveBeenCalled()
 })
 
 test('No backend is present', async () => {


### PR DESCRIPTION
## Description

We need a way to build actions in an app, without wiping out all the contents of the `dist` folder.
This is to facilitate fast turnaround time for action editing and debugging using the [dev plugin](https://github.com/adobe/aio-cli-plugin-app-dev). If not, we would have to build all the actions everytime one action is built, which increases latency.

Adding a new param, so it doesn't break existing users since the default value for `emptyDist` will be `true`.

## Related Issue

https://github.com/adobe/aio-cli-plugin-app-dev/pull/87

## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
