### PR TITLE
fix: ACNA-3239 - hash dependencies not in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@adobe/aio-lib-core-networking": "^5",
     "@adobe/aio-lib-env": "^3.0.0",
     "archiver": "^6.0.1",
+    "dependency-tree": "^11.0.1",
     "execa": "^4.0.3",
     "folder-hash": "^4.0.4",
     "fs-extra": "^11.1.1",

--- a/test/__mocks__/dependency-tree.js
+++ b/test/__mocks__/dependency-tree.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = {
+  toList ({ filter }) {
+    return [
+      'actions/action2/index.js',
+      'node_modules/dependency-tree/index.js'
+    ].filter(filter)
+  }
+}

--- a/test/__mocks__/folder-hash.js
+++ b/test/__mocks__/folder-hash.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = {
+  hashElement () {
+    return { hash: 'asdersd' }
+  }
+}

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -13,7 +13,7 @@ const utils = require('../src/utils')
 const buildActions = require('../src/build-actions')
 const path = require('path')
 const fs = require('fs-extra')
-
+jest.mock('dependency-tree')
 const execa = require('execa')
 jest.mock('execa')
 const deepClone = require('lodash.clonedeep')
@@ -1160,6 +1160,18 @@ test('should not zip files if the action was built before (skipCheck=false)', as
   addSampleAppFiles()
   const config = deepClone(global.sampleAppConfig)
   await buildActions(config, ['action'], false)
+  expect(utils.zip).not.toHaveBeenCalled()
+})
+
+test('should not build if required file is not changed', async () => {
+  addSampleAppFiles()
+
+  const config = deepClone(global.sampleAppConfig)
+  await buildActions(config, ['action'], false)
+  expect(mockLogger.debug).toHaveBeenCalledWith(
+    expect.stringContaining('action has changed since last build, building ..'),
+    expect.any(String)
+  )
   expect(utils.zip).not.toHaveBeenCalled()
 })
 

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -1165,14 +1165,18 @@ test('should not zip files if the action was built before (skipCheck=false)', as
 
 test('should not build if required file is not changed', async () => {
   addSampleAppFiles()
-
   const config = deepClone(global.sampleAppConfig)
-  await buildActions(config, ['action'], false)
+  await buildActions(config, ['action'], true)
   expect(mockLogger.debug).toHaveBeenCalledWith(
     expect.stringContaining('action has changed since last build, building ..'),
     expect.any(String)
   )
-  expect(utils.zip).not.toHaveBeenCalled()
+  mockLogger.debug.mockClear()
+  await buildActions(config, ['action'], false)
+  expect(mockLogger.debug).toHaveBeenCalledWith(
+    expect.stringContaining('action has not changed')
+  )
+  expect(utils.zip).toHaveBeenCalledTimes(1)
 })
 
 test('should not delete dist folder when emptyDist=false', async () => {


### PR DESCRIPTION


## Description

This pr adds dependent files to the hash it generates during build.  Note that these files are still not watched, but if they change between run/dev/build it is detected.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
