### PR TITLE
Support .cjs extension for webpack config

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -40,7 +40,7 @@ const getWebpackConfigPath = async (actionPath, root) => {
   let configPath = null
 
   do {
-    const paths = await globby([path.join(parentDir, '*webpack-config.js')])
+    const paths = await globby([path.join(parentDir, '*webpack-config.{js,cjs}')])
     if (paths && paths.length > 0) {
       configPath = paths[0]
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support .cjs extensions for `webpack-config` file resolution

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I understand that full support for es modules is not here yet, however, with this small change we can allow devs to build their apps with es modules while hooking in webpack as a commonJs module in the same repo.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
