### PR TITLE
fix: use posix paths with globby regardless of platform

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -27,8 +27,8 @@ const uniqueArr = (items) => {
 }
 
 const toPosixPath = (path) => {
-  return path.replace(/^[A-Z]:/, '').replaceAll("\\", "/");
-};
+  return path.replace(/^[A-Z]:/, '').replaceAll('\\', '/')
+}
 
 /**
  *  Searches for a webpack config file, starting at the action path and working

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -26,6 +26,10 @@ const uniqueArr = (items) => {
   return [...new Set(items)]
 }
 
+const toPosixPath = (path) => {
+  return path.replace(/^[A-Z]:/, '').replaceAll("\\", "/");
+};
+
 /**
  *  Searches for a webpack config file, starting at the action path and working
  *  towards the root of the project. Will return the first one it finds.
@@ -35,9 +39,10 @@ const uniqueArr = (items) => {
  * @returns {Promise<string>} Webpack config file path, will be 'null' if not found
  */
 const getWebpackConfigPath = async (actionPath, root) => {
-  const posixActionPath = actionPath.replaceAll('\\', '/')
+  const posixRoot = toPosixPath(root)
+  const posixActionPath = toPosixPath(actionPath)
   let parentDir = path.posix.dirname(posixActionPath)
-  const rootParent = path.resolve(path.posix.dirname(root))
+  const rootParent = path.posix.resolve(path.posix.dirname(posixRoot))
   let configPath = null
 
   do {

--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -35,12 +35,13 @@ const uniqueArr = (items) => {
  * @returns {Promise<string>} Webpack config file path, will be 'null' if not found
  */
 const getWebpackConfigPath = async (actionPath, root) => {
-  let parentDir = path.dirname(actionPath)
-  const rootParent = path.resolve(path.dirname(root))
+  const posixActionPath = actionPath.replaceAll('\\', '/')
+  let parentDir = path.posix.dirname(posixActionPath)
+  const rootParent = path.resolve(path.posix.dirname(root))
   let configPath = null
 
   do {
-    const paths = await globby([path.join(parentDir, '*webpack-config.{js,cjs}')])
+    const paths = await globby([path.posix.join(parentDir, '*webpack-config.{js,cjs}')])
     if (paths && paths.length > 0) {
       configPath = paths[0]
     }

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -346,7 +346,7 @@ describe('build by bundling js action file with webpack', () => {
       },
       target: 'node'
     }])
-    expect(globby).toHaveBeenCalledWith(expect.arrayContaining([path.resolve('/actions/*webpack-config.{js,cjs}')]))
+    expect(globby).toHaveBeenCalledWith(expect.arrayContaining([path.posix.resolve('/actions/*webpack-config.{js,cjs}')]))
     expect(utils.zip).toHaveBeenCalledWith(path.normalize('/dist/actions/sample-app-include-1.0.0/action-temp'),
       path.normalize('/dist/actions/sample-app-include-1.0.0/action.zip'))
     expect(Object.keys(global.fakeFileSystem.files())).toEqual(expect.arrayContaining(['/includeme.txt']))
@@ -394,7 +394,7 @@ describe('build by bundling js action file with webpack', () => {
       },
       target: 'node'
     }])
-    expect(globby).toHaveBeenCalledWith(expect.arrayContaining([path.resolve('/actions/*webpack-config.{js,cjs}')]))
+    expect(globby).toHaveBeenCalledWith(expect.arrayContaining([path.posix.resolve('/actions/*webpack-config.{js,cjs}')]))
     expect(utils.zip).toHaveBeenCalledWith(path.normalize('/dist/actions/sample-app-include-1.0.0/action-temp'),
       path.normalize('/dist/actions/sample-app-include-1.0.0/action.zip'))
     expect(Object.keys(global.fakeFileSystem.files())).toEqual(expect.arrayContaining(['/includeme.txt']))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #210 

On Windows only, when trying to use a custom webpack config per: https://developer.adobe.com/app-builder/docs/guides/configuration/webpack-configuration, the config is never loaded.


This PR fixes that by providing `globby`, the library used to resolve the config, with a POSIX path instead of a windows path. Per [globby docs](https://github.com/sindresorhus/globby/blob/main/readme.md#api)

>Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use path.posix.join() instead of path.join().

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

tested it locally on my project on windows

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
