### PR TITLE
fix: log forwarding does not take into account auth_handler Openwhisk option

### DIFF
--- a/src/LogForwarding.js
+++ b/src/LogForwarding.js
@@ -162,7 +162,7 @@ class LogForwarding {
 
     let Authorization = `Basic ${Buffer.from(this.auth).toString('base64')}`
     if (this.authHandler?.getAuthHeader && typeof this.authHandler?.getAuthHeader === 'function') {
-      Authorization = this.authHandler.getAuthHeader()
+      Authorization = await this.authHandler.getAuthHeader()
     }
 
     const fetch = createFetch()

--- a/src/RuntimeAPI.js
+++ b/src/RuntimeAPI.js
@@ -89,7 +89,8 @@ class RuntimeAPI {
         clonedOptions.namespace,
         clonedOptions.apihost,
         clonedOptions.api_key,
-        new LogForwardingLocalDestinationsProvider()
+        new LogForwardingLocalDestinationsProvider(),
+        clonedOptions.auth_handler
       ),
       initOptions: clonedOptions
     }

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -70,7 +70,7 @@ test('get', async () => {
 test('get with auth handler', async () => {
   const authorizationHeader = 'Bearer token'
   const authHandler = {
-    getAuthHeader: jest.fn().mockReturnValue(authorizationHeader)
+    getAuthHeader: jest.fn().mockResolvedValue(authorizationHeader)
   }
   logForwarding = new LogForwarding(
     'some_namespace',

--- a/test/LogForwarding.test.js
+++ b/test/LogForwarding.test.js
@@ -67,6 +67,37 @@ test('get', async () => {
   })
 })
 
+test('get with auth handler', async () => {
+  const authorizationHeader = 'Bearer token'
+  const authHandler = {
+    getAuthHeader: jest.fn().mockReturnValue(authorizationHeader)
+  }
+  logForwarding = new LogForwarding(
+    'some_namespace',
+    'host',
+    'key',
+    new LogForwardingLocalDestinationsProvider(),
+    authHandler
+  )
+  expect(logForwarding.authHandler).toEqual(authHandler)
+
+  return new Promise(resolve => {
+    mockFetch.mockReturnValue(new Promise(resolve => {
+      resolve({
+        ok: true,
+        json: jest.fn().mockResolvedValue('result')
+      })
+    }))
+    return logForwarding.get()
+      .then((res) => {
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        expect(res).toBe('result')
+        assertRequest('get', undefined, '', authorizationHeader)
+        resolve()
+      })
+  })
+})
+
 test('get request failed', async () => {
   mockFetch.mockRejectedValue(new Error('mocked error'))
   await expect(logForwarding.get()).rejects.toThrow("Could not get log forwarding settings for namespace 'some_namespace': mocked error")
@@ -216,13 +247,18 @@ test('could not get errors', async () => {
     .rejects.toThrow("Could not get log forwarding errors for namespace 'some_namespace': mocked error")
 })
 
-const assertRequest = (expectedMethod, expectedData, expectedSubPath = '') => {
+const assertRequest = (
+  expectedMethod,
+  expectedData,
+  expectedSubPath = '',
+  expectedAuthorization = `Basic ${Buffer.from('key').toString('base64')}`
+) => {
   expect(mockFetch).toHaveBeenCalledWith(apiUrl + expectedSubPath, {
     method: expectedMethod,
     body: JSON.stringify(expectedData),
     headers: {
       'Content-Type': 'application/json',
-      Authorization: 'Basic ' + Buffer.from('key').toString('base64')
+      Authorization: expectedAuthorization
     }
   })
 }


### PR DESCRIPTION
fixes #211 

## How Has This Been Tested?

- in a locally linked app plugin, `npm i github:adobe/aio-lib-runtime#story/ACNA-3770`
- in an AB project, run `aio app config set lf`
- if env var `IS_DEPLOY_SERVICE_ENABLED` is set to true, the fetch call should have the bearer token header

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
