### PR TITLE
fix: deploying actions with require-adobe-auth not working with deploy-service

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,13 @@ const archiver = require('archiver')
 // this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
 const SupportedRuntimes = ['sequence', 'blackbox', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20', 'nodejs:22']
 
+const SUPPORTED_ADOBE_ANNOTATION_ENDPOINTS = [
+  'https://adobeioruntime.net',
+  'https://deploy-service.dev.app-builder.corp.adp.adobe.io/runtime',
+  'https://deploy-service.stg.app-builder.corp.adp.adobe.io/runtime',
+  'https://deploy-service.app-builder.adp.adobe.io/runtime'
+]
+
 const DEFAULT_PACKAGE_RESERVED_NAME = 'default'
 const ANNOTATION_WEB_EXPORT = 'web-export'
 const ANNOTATION_RAW_HTTP = 'raw-http'
@@ -1193,7 +1200,9 @@ function processPackage (packages,
   // eslint - do not rewrite function arguments
   let pkgs = packages
   let deploymentPkgs = deploymentPackages
-  if (owOptions.apihost === 'https://adobeioruntime.net') {
+
+  const isAdobeEndpoint = SUPPORTED_ADOBE_ANNOTATION_ENDPOINTS.includes(owOptions.apihost)
+  if (isAdobeEndpoint) {
     // rewrite packages in case there are any `require-adobe-auth` annotations
     // this is a temporary feature and will be replaced by a native support in Adobe I/O Runtime
     const { newPackages, newDeploymentPackages } = rewriteActionsWithAdobeAuthAnnotation(pkgs, deploymentPkgs)


### PR DESCRIPTION
## Description

`require-adobe-auth` annotation was not working in v14 of the app plugin. This is because we rewrite an action definition to be behind a sequence with validators when we see this annotation but only for an allowlist of endpoints, and the deploy-service was not in this list. This annotation is in turn only supported by Adobe and not supported for a general OW instance. 

Technically aio-lib-runtime (and aio-cli-plugin-runtime) can be used on general OW servers so we should not generally apply this annotation.

I also re-factored the `require-adobe-auth` annotation tests -- 10 tests were in 1 function (not best practice to surface unit test failures because of a pre-emptive fail), I broke it out into 10 tests in a separate describe block. I also added three new tests for the 3 new endpoints.

## Related Issue

Closes https://github.com/adobe/aio-cli/issues/761

## How Has This Been Tested?

- linked the patched aio-lib-runtime into the app plugin
- deploy a web action with annotation `require-adobe-auth: true`
- `curl` (GET) the action, it should return a 401 HTTP status (expected)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
