### PR TITLE
fix: for deploy service int interfaces, and apihost get urls output

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,17 +22,16 @@ const archiver = require('archiver')
 // this is a static list that comes from here: https://developer.adobe.com/runtime/docs/guides/reference/runtimes/
 const SupportedRuntimes = ['sequence', 'blackbox', 'nodejs:10', 'nodejs:12', 'nodejs:14', 'nodejs:16', 'nodejs:18', 'nodejs:20', 'nodejs:22']
 
+// must cover 'deploy-service[-region][.env].app-builder[.int|.corp].adp.adobe.io/runtime
 const SUPPORTED_ADOBE_ANNOTATION_ENDPOINT_REGEXES = [
   /http(s)?:\/\/localhost/,
   /http(s)?:\/\/127\.0\.0\.1/,
   /https:\/\/adobeioruntime\.net/,
-  /https:\/\/deploy-service.*\.app-builder\.corp\.adp\.adobe\.io\/runtime/,
-  /https:\/\/deploy-service.*\.app-builder\.adp\.adobe\.io\/runtime/
+  /https:\/\/deploy-service.*\.app-builder.*\.adp\.adobe\.io\/runtime/
 ]
 const NON_CUSTOM_ADOBE_APIHOSTS_REGEXES = [
   /adobeioruntime\.net/,
-  /deploy-service.*\.app-builder\.corp\.adp\.adobe\.io\/runtime/,
-  /deploy-service.*\.app-builder\.adp\.adobe\.io\/runtime/
+  /deploy-service.*\.app-builder.*\.adp\.adobe\.io\/runtime/
 ]
 
 const DEFAULT_PACKAGE_RESERVED_NAME = 'default'
@@ -1917,8 +1916,10 @@ function getActionUrls (appConfig, /* istanbul ignore next */ isRemoteDev = fals
     } else {
       // if (!actionIsBehindCdn && !apihostIsCustom)
       // https://<ns>.adobeioruntime.net/api/v1/web/<package>/<action>
+      // note: if the apihost matches /deploy-service.*\.app-builder\.*\.adp\.adobe\.io\/runtime/
+      //       we still want to serve dataplane requests on adobeioruntime.net
       return urlJoin(
-        'https://' + config.ow.namespace + '.' + cleanApihost,
+        'https://' + config.ow.namespace + '.' + 'adobeioruntime.net',
         'api',
         config.ow.apiversion,
         webUri,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2217,6 +2217,96 @@ describe('getActionUrls', () => {
     expect(result).toEqual(expected)
   })
 
+  test('some non web actions, with ui, deploy-service prod environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service.app-builder.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
+  test('some non web actions, with ui, deploy-service-region prod environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service-va6.app-builder.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
+  test('some non web actions, with ui, deploy-service-region prod int environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service-va6.app-builder.int.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
+  test('some non web actions, with ui, deploy-service-region stg corp environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service-va6.stg.app-builder.corp.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
+  test('some non web actions, with ui, deploy-service-region stg int environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service-va6.stg.app-builder.int.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
+  test('some non web actions, with ui, deploy-service-region dev int environment apihost, no custom hostname', () => {
+    const expected = {
+      'sample-app-1.0.0/action': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+      'sample-app-1.0.0/action-sequence': 'https://fake_ns.adobeioruntime.net/api/v1/sample-app-1.0.0/action-sequence',
+      'sample-app-1.0.0/action-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip',
+      'pkg2/thataction': 'https://fake_ns.adobeioruntime.net/api/v1/pkg2/thataction',
+      'pkg2/thatsequence': 'https://fake_ns.adobeio-static.net/api/v1/web/pkg2/thatsequence'
+    }
+    config.ow.apihost = 'deploy-service-va6.dev.app-builder.int.adp.adobe.io/runtime'
+    config.manifest.full.packages.__APP_PACKAGE__.sequences['action-sequence'].web = 'no'
+    config.manifest.full.packages.pkg2.actions.thataction.web = 'no'
+    const result = utils.getActionUrls(config, false, false)
+    expect(result).toEqual(expected)
+  })
+
   test('some non web actions, with ui, remote dev, no custom apihost, no custom hostname', () => {
     const expected = {
       'sample-app-1.0.0/action': 'https://fake_ns.adobeioruntime.net/api/v1/web/sample-app-1.0.0/action',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

follow up on #219 
- support adobe annotations for deploy service also on `int` interfaces
- fix apihost in `getActionUrls`, should return `adobeioruntime.net` for action urls as deploy service is only used on control-plane.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
