### PR TITLE
fix: IOEXT-1726 `aio app dev` fails when project package.json has `"type": "module"`

### DIFF
--- a/src/build-actions.js
+++ b/src/build-actions.js
@@ -242,6 +242,17 @@ const prepareToBuildAction = async (action, root, dist) => {
         return resolve(stats)
       })
     })
+
+    // Fix for IOEXT-1726: webpack emits CommonJS (libraryTarget: 'commonjs2'),
+    // but Node walks up the directory tree to find the closest package.json
+    // when deciding the module type for the bundled index.js. If the user's
+    // project sets "type": "module" (ESM), Node parses the CJS bundle as ESM
+    // and aio-cli-plugin-app-dev's require()-based loader fails with
+    // "action not found, or does not export main". Drop a sibling package.json
+    // that pins the bundle output to CommonJS regardless of the project type.
+    fs.writeJsonSync(path.join(tempBuildDir, 'package.json'), {
+      type: 'commonjs'
+    })
   }
 
   return {

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -278,6 +278,30 @@ describe('build by bundling js action file with webpack', () => {
       path.normalize('/dist/actions/sample-app-1.0.0/action.zip'))
   })
 
+  test('should drop a sibling package.json with type: commonjs in the webpack temp dir (IOEXT-1726)', async () => {
+    await buildActions(config)
+
+    const tempDir = path.normalize('/dist/actions/sample-app-1.0.0/action-temp')
+
+    // confirm webpack was asked to emit the bundle to the expected temp dir
+    expect(webpack).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({
+        output: expect.objectContaining({
+          path: tempDir,
+          filename: 'index.js'
+        })
+      })
+    ]))
+
+    // the sibling package.json must scope the bundle as CommonJS so that Node
+    // does not treat it as ESM when the user's project package.json declares
+    // "type": "module".
+    const siblingPath = path.join(tempDir, 'package.json')
+    const siblingRaw = global.fakeFileSystem.files()[siblingPath]
+    expect(siblingRaw).toBeDefined()
+    expect(JSON.parse(siblingRaw)).toEqual({ type: 'commonjs' })
+  })
+
   test('should bundle a single action file using webpack and zip it with includes', async () => {
     global.fakeFileSystem.reset()
     global.fakeFileSystem.addJson({

--- a/test/build.actions.test.js
+++ b/test/build.actions.test.js
@@ -296,7 +296,7 @@ describe('build by bundling js action file with webpack', () => {
     // the sibling package.json must scope the bundle as CommonJS so that Node
     // does not treat it as ESM when the user's project package.json declares
     // "type": "module".
-    const siblingPath = path.join(tempDir, 'package.json')
+    const siblingPath = path.join(tempDir, 'package.json').split(path.sep).join('/')
     const siblingRaw = global.fakeFileSystem.files()[siblingPath]
     expect(siblingRaw).toBeDefined()
     expect(JSON.parse(siblingRaw)).toEqual({ type: 'commonjs' })


### PR DESCRIPTION
## Summary

Fixes [IOEXT-1726](https://jira.corp.adobe.com/browse/IOEXT-1726): every web action returns `400 "<action> action not found, or does not export main"` from `aio app dev` when the user's project `package.json` declares `"type": "module"`. `aio app deploy` is unaffected.

Reproduction (with `@adobe/aio-cli@11.1.0`, `@adobe/aio-lib-runtime@7.3.0`, Node 22 or 24):

```bash
git clone https://github.com/adobe/commerce-checkout-starter-kit
cd commerce-checkout-starter-kit
npm install
# remove `require-adobe-auth: true` from the `info` action in app.config.yaml
aio app dev -e application
curl -k https://localhost:9080/api/v1/web/commerce-checkout-starter-kit/info
# {"error":"Response is not valid 'message/http'. info action not found, or does not export main"}
```

## Root cause

`prepareToBuildAction` writes a webpack bundle to `<dist>/<pkg>/<action>-temp/index.js` with `libraryTarget: 'commonjs2'`, but does not drop a sibling `package.json`. Node decides the bundle's module type by walking up to the closest `package.json`, which is the user's project root. When that file has `"type": "module"`, Node parses the CommonJS bundle as ESM. `@adobe/aio-cli-plugin-app-dev`'s `defaultActionLoader` in [`run-dev.js`](https://github.com/adobe/aio-cli-plugin-app-dev/blob/main/src/lib/run-dev.js) calls `require(actionPath)`, which throws, gets caught, and surfaces the misleading `"<action> action not found, or does not export main"` message.

`aio app deploy` is unaffected because the deployed bundle runs in an OpenWhisk Node container with no parent `package.json` to interfere.

## Fix

After webpack writes the bundle, drop a sibling `package.json` pinning the bundle to CommonJS. This is a one-line change inside `prepareToBuildAction`'s non-directory branch:

```javascript
fs.writeJsonSync(path.join(tempBuildDir, 'package.json'), { type: 'commonjs' })
```

The sibling is the closest ancestor `package.json` Node finds when resolving the bundled `index.js`, so it wins regardless of the project's setting. The change is invisible to deploy: the OpenWhisk Node runtime treats bundled `.js` actions as CJS already, and an explicit `{ type: 'commonjs' }` is consistent with the bundle's actual format.

## Scope

This fixes **single-file (webpack-bundled) actions**, which is the case in the bug report. Directory-style actions written in ESM would also need the dev plugin's loader to switch from `require()` to dynamic `import()`; tracked separately as [ACNA-4604](https://jira.corp.adobe.com/browse/ACNA-4604).

## Test plan

- [x] New unit test in `test/build.actions.test.js` asserts `prepareToBuildAction` writes `<temp>/package.json` with `{ type: 'commonjs' }` next to the bundled `index.js`
- [x] Full test suite passes (457/457, 100% coverage maintained)
- [x] Manual repro per IOEXT-1726:
  - Without patch: `curl /info` → HTTP 400, `"info action not found, or does not export main"` ✗
  - With patch:    `curl /info` → HTTP 200 ✓
- [x] No deploy regression: deploy path is unchanged for the OpenWhisk runtime; the extra `package.json` in the zip just makes the bundle's CJS-ness explicit.

## Risk

Very low. The change only touches output produced for webpack-bundled (single-file) actions. Existing tests continue to pass; the new test locks in the contract.