### PR TITLE
fix: aio app deploy fails when packages: {} is declared

### DIFF
--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -57,9 +57,12 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   // checks
   // a. missing credentials
   utils.checkOpenWhiskCredentials(config)
-  // b. missing build files
+  // b. missing build files — only required when at least one package defines actions
   const dist = config.actions.dist
+  const hasAnyActions = Object.values(config.manifest.full.packages)
+    .some(pkg => Object.keys(pkg.actions || {}).length > 0)
   if (
+    hasAnyActions &&
     (!deployConfig.filterEntities || deployConfig.filterEntities.actions) &&
     (!fs.pathExistsSync(dist) || !fs.lstatSync(dist).isDirectory() || !fs.readdirSync(dist).length === 0)
   ) {

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -61,6 +61,9 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   const dist = config.actions.dist
   const hasAnyActions = Object.values(config.manifest.full.packages)
     .some(pkg => Object.keys(pkg.actions || {}).length > 0)
+  if (!hasAnyActions) {
+    log('Warning: no actions defined in manifest — deploy is a no-op and will undeploy any previously-deployed actions for this project.')
+  }
   if (
     hasAnyActions &&
     (!deployConfig.filterEntities || deployConfig.filterEntities.actions) &&

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -57,13 +57,20 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   // checks
   // a. missing credentials
   utils.checkOpenWhiskCredentials(config)
-  // b. missing build files — only required when at least one package defines actions
-  const dist = config.actions.dist
-  const hasAnyActions = Object.values(config.manifest.full.packages)
-    .some(pkg => Object.keys(pkg.actions || {}).length > 0)
-  if (!hasAnyActions) {
-    log('Warning: no actions defined in manifest, deploy is a no-op and will undeploy any previously-deployed actions for this project.')
+  // b. no packages declared (e.g. `packages: {}`, used only to trigger database
+  // auto-provisioning). Skip deployment entirely. Proceeding would run a full
+  // sync against an empty manifest, undeploying every previously-deployed entity
+  // for the project. Use `aio app undeploy` to intentionally remove all entities.
+  const packages = config.manifest.full.packages
+  if (Object.keys(packages).length === 0) {
+    log('Warning: no packages defined in the manifest, skipping deployment. Existing deployed entities are left untouched; use \'aio app undeploy\' to remove them.')
+    return {}
   }
+
+  // c. missing build files — only required when at least one package defines actions
+  const dist = config.actions.dist
+  const hasAnyActions = Object.values(packages)
+    .some(pkg => Object.keys(pkg.actions || {}).length > 0)
   if (
     hasAnyActions &&
     (!deployConfig.filterEntities || deployConfig.filterEntities.actions) &&

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -62,7 +62,7 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   const hasAnyActions = Object.values(config.manifest.full.packages)
     .some(pkg => Object.keys(pkg.actions || {}).length > 0)
   if (!hasAnyActions) {
-    log('Warning: no actions defined in manifest — deploy is a no-op and will undeploy any previously-deployed actions for this project.')
+    log('Warning: no actions defined in manifest, deploy is a no-op and will undeploy any previously-deployed actions for this project.')
   }
   if (
     hasAnyActions &&

--- a/src/deploy-actions.js
+++ b/src/deploy-actions.js
@@ -67,7 +67,7 @@ async function deployActions (config, deployConfig = {}, logFunc) {
   if (
     hasAnyActions &&
     (!deployConfig.filterEntities || deployConfig.filterEntities.actions) &&
-    (!fs.pathExistsSync(dist) || !fs.lstatSync(dist).isDirectory() || !fs.readdirSync(dist).length === 0)
+    (!fs.pathExistsSync(dist) || !fs.lstatSync(dist).isDirectory() || fs.readdirSync(dist).length === 0)
   ) {
     throw new Error(`missing files in ${utils._relApp(config.root, dist)}, maybe you forgot to build your actions ?`)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2104,7 +2104,9 @@ function replacePackagePlaceHolder (config) {
     // Using custom package name.
     // Set config.ow.package so that syncProject can use it as project name for annotations.
     const packageNames = Object.keys(packages)
-    modifiedConfig.ow.package = packageNames[0]
+    if (packageNames.length > 0) {
+      modifiedConfig.ow.package = packageNames[0]
+    }
   }
   return modifiedConfig
 }

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -583,18 +583,22 @@ test('Deploy actions should pass if there are no build files and filter does not
   await expect(deployActions(global.sampleAppConfig, { filterEntities: { triggers: ['trigger1'] } })).resolves.toEqual({})
 })
 
-test('Deploy actions should succeed when packages: {} (empty packages, no actions defined)', async () => {
+test('Deploy actions should succeed and warn when packages: {} (empty packages, no actions defined)', async () => {
   const emptyPackagesConfig = deepCopy(global.sampleAppConfig)
   emptyPackagesConfig.manifest.full.packages = {}
   runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
-  await expect(deployActions(emptyPackagesConfig)).resolves.toBeDefined()
+  const logSpy = jest.fn()
+  await expect(deployActions(emptyPackagesConfig, {}, logSpy)).resolves.toBeDefined()
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no actions defined in manifest'))
 })
 
-test('Deploy actions should succeed when a package has no actions key (pkg.actions || {} guard)', async () => {
+test('Deploy actions should succeed and warn when a package has no actions key (pkg.actions || {} guard)', async () => {
   const noActionsPkgConfig = deepCopy(global.sampleAppConfig)
   noActionsPkgConfig.manifest.full.packages = { emptyPkg: {} }
   runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
-  await expect(deployActions(noActionsPkgConfig)).resolves.toBeDefined()
+  const logSpy = jest.fn()
+  await expect(deployActions(noActionsPkgConfig, {}, logSpy)).resolves.toBeDefined()
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no actions defined in manifest'))
 })
 
 // lonely

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -591,22 +591,14 @@ test('Deploy actions should pass if there are no build files and filter does not
   await expect(deployActions(global.sampleAppConfig, { filterEntities: { triggers: ['trigger1'] } })).resolves.toEqual({})
 })
 
-test('Deploy actions should succeed and warn when packages: {} (empty packages, no actions defined)', async () => {
+test('Deploy actions should be a no-op (no undeploy) and warn when packages: {} (empty packages)', async () => {
   const emptyPackagesConfig = deepCopy(global.sampleAppConfig)
   emptyPackagesConfig.manifest.full.packages = {}
-  runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
   const logSpy = jest.fn()
-  await expect(deployActions(emptyPackagesConfig, {}, logSpy)).resolves.toBeDefined()
-  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no actions defined in manifest'))
-})
-
-test('Deploy actions should succeed and warn when a package has no actions key (pkg.actions || {} guard)', async () => {
-  const noActionsPkgConfig = deepCopy(global.sampleAppConfig)
-  noActionsPkgConfig.manifest.full.packages = { emptyPkg: {} }
-  runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
-  const logSpy = jest.fn()
-  await expect(deployActions(noActionsPkgConfig, {}, logSpy)).resolves.toBeDefined()
-  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no actions defined in manifest'))
+  await expect(deployActions(emptyPackagesConfig, {}, logSpy)).resolves.toEqual({})
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no packages defined'))
+  // must not run a full sync that would undeploy previously-deployed entities
+  expect(runtimeLibUtils.syncProject).not.toHaveBeenCalled()
 })
 
 // lonely

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -583,6 +583,20 @@ test('Deploy actions should pass if there are no build files and filter does not
   await expect(deployActions(global.sampleAppConfig, { filterEntities: { triggers: ['trigger1'] } })).resolves.toEqual({})
 })
 
+test('Deploy actions should succeed when packages: {} (empty packages, no actions defined)', async () => {
+  const emptyPackagesConfig = deepCopy(global.sampleAppConfig)
+  emptyPackagesConfig.manifest.full.packages = {}
+  runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
+  await expect(deployActions(emptyPackagesConfig)).resolves.toBeDefined()
+})
+
+test('Deploy actions should succeed when a package has no actions key (pkg.actions || {} guard)', async () => {
+  const noActionsPkgConfig = deepCopy(global.sampleAppConfig)
+  noActionsPkgConfig.manifest.full.packages = { emptyPkg: {} }
+  runtimeLibUtils.processPackage.mockReturnValue(deepCopy(mockEntities))
+  await expect(deployActions(noActionsPkgConfig)).resolves.toBeDefined()
+})
+
 // lonely
 test('if actions are deployed and part of the manifest it should return their url', async () => {
   addSampleAppReducedFiles()

--- a/test/deploy.actions.test.js
+++ b/test/deploy.actions.test.js
@@ -577,6 +577,14 @@ test('Deploy actions should fail if there are no build files and action filter',
     .rejects.toThrow('missing files in dist')
 })
 
+test('Deploy actions should fail if the build directory exists but is empty', async () => {
+  addSampleAppFiles()
+  // dist exists as a directory but contains no built actions
+  global.fakeFileSystem.addJson({ [global.sampleAppConfig.actions.dist]: null })
+  await expect(deployActions(global.sampleAppConfig))
+    .rejects.toThrow('missing files in dist')
+})
+
 test('Deploy actions should pass if there are no build files and filter does not include actions', async () => {
   addSampleAppFiles()
   runtimeLibUtils.processPackage.mockReturnValue({})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3097,3 +3097,43 @@ describe('loadIMSCredentialsFromEnv', () => {
     expect(result.scopes).toBe('not json')
   })
 })
+
+describe('replacePackagePlaceHolder', () => {
+  test('leaves ow.package unchanged when packages is empty (packages: {})', () => {
+    const config = {
+      ow: { package: 'my-pkg' },
+      manifest: {
+        packagePlaceholder: '__APP_PACKAGE__',
+        full: { packages: {} }
+      }
+    }
+    const result = utils.replacePackagePlaceHolder(config)
+    expect(result.ow.package).toBe('my-pkg')
+  })
+
+  test('renames placeholder package to ow.package', () => {
+    const config = {
+      ow: { package: 'my-pkg' },
+      manifest: {
+        packagePlaceholder: '__APP_PACKAGE__',
+        full: { packages: { __APP_PACKAGE__: { actions: {} } } }
+      }
+    }
+    const result = utils.replacePackagePlaceHolder(config)
+    expect(result.ow.package).toBe('my-pkg')
+    expect(result.manifest.full.packages['my-pkg']).toBeDefined()
+    expect(result.manifest.full.packages.__APP_PACKAGE__).toBeUndefined()
+  })
+
+  test('sets ow.package to first package name when no placeholder matches', () => {
+    const config = {
+      ow: { package: 'ignored' },
+      manifest: {
+        packagePlaceholder: '__APP_PACKAGE__',
+        full: { packages: { 'custom-pkg': { actions: {} } } }
+      }
+    }
+    const result = utils.replacePackagePlaceHolder(config)
+    expect(result.ow.package).toBe('custom-pkg')
+  })
+})


### PR DESCRIPTION
## Summary

- When a manifest declares `packages: {}` (empty packages), the build step produces no output so the dist directory is never created. The deploy command was throwing a spurious **"missing files in dist/…, maybe you forgot to build your actions?"** error.
- A secondary issue in `replacePackagePlaceHolder` silently set `ow.package = undefined` when packages was empty, causing `syncProject` to search the runtime server for a project named `undefined`.

## Changes

**`src/deploy-actions.js`**
Gate the dist-existence check behind `hasAnyActions` — only validate the build directory when at least one package actually declares actions. Removed the redundant `|| {}` fallback (packages is always an object at this point) and the dead `pkg && ` guard (null-valued packages already fail elsewhere in the pipeline).

**`src/utils.js` (`replacePackagePlaceHolder`)**
Guard the `packageNames[0]` assignment so an empty packages object no longer clobbers `ow.package` with `undefined`.

> [!NOTE]
> Deploying with `packages: {}` is effectively a no-op — no package, action, trigger, rule, or API is created on Adobe I/O Runtime. If the project was previously deployed with actual entities, the runtime's sync mechanism will treat the empty manifest as the desired state and undeploy them. This is consistent with how the full-sync model works in general, though it may be unexpected if packages: {} is used as a placeholder during development.